### PR TITLE
[Feat] Add timezone-aware bucketing to statistics timeseries

### DIFF
--- a/internal/modules/adminstats/statistics_constants.go
+++ b/internal/modules/adminstats/statistics_constants.go
@@ -6,6 +6,10 @@ const (
 )
 
 const (
-	timeseriesBucketHour = "hour"
-	timeseriesBucketDay  = "day"
+	timeseriesBucketHour  = "hour"
+	timeseriesBucketDay   = "day"
+	timeseriesBucketWeek  = "week"
+	timeseriesBucketMonth = "month"
 )
+
+const defaultStatisticsTimezone = "UTC"

--- a/internal/modules/adminstats/statistics_handlers.go
+++ b/internal/modules/adminstats/statistics_handlers.go
@@ -34,7 +34,12 @@ func handleGetStatisticsTimeseries(apiHelper *harukiAPIHelper.HarukiToolboxRoute
 			return respondFiberOrBadRequest(c, err, "invalid bucket")
 		}
 
-		resp, err := buildStatisticsTimeseries(c, apiHelper, from, to, bucket)
+		tz, loc, err := parseStatisticsTimezone(c.Query("tz"))
+		if err != nil {
+			return respondFiberOrBadRequest(c, err, "invalid timezone")
+		}
+
+		resp, err := buildStatisticsTimeseries(c, apiHelper, from, to, bucket, tz, loc)
 		if err != nil {
 			return harukiAPIHelper.ErrorInternal(c, "failed to build statistics timeseries")
 		}

--- a/internal/modules/adminstats/statistics_parse.go
+++ b/internal/modules/adminstats/statistics_parse.go
@@ -3,6 +3,7 @@ package adminstats
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 )
@@ -34,9 +35,25 @@ func parseStatisticsTimeseriesBucket(raw string) (string, error) {
 		return timeseriesBucketHour, nil
 	}
 	switch trimmed {
-	case timeseriesBucketHour, timeseriesBucketDay:
+	case timeseriesBucketHour, timeseriesBucketDay, timeseriesBucketWeek, timeseriesBucketMonth:
 		return trimmed, nil
 	default:
-		return "", fiber.NewError(fiber.StatusBadRequest, "bucket must be one of: hour, day")
+		return "", fiber.NewError(fiber.StatusBadRequest, "bucket must be one of: hour, day, week, month")
 	}
+}
+
+// parseStatisticsTimezone resolves the IANA timezone used to align timeseries
+// buckets to local calendar boundaries. An empty value defaults to UTC, keeping
+// the previous behaviour for callers that do not provide a timezone.
+func parseStatisticsTimezone(raw string) (string, *time.Location, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return defaultStatisticsTimezone, time.UTC, nil
+	}
+
+	loc, err := time.LoadLocation(trimmed)
+	if err != nil {
+		return "", nil, fiber.NewError(fiber.StatusBadRequest, "invalid timezone")
+	}
+	return trimmed, loc, nil
 }

--- a/internal/modules/adminstats/statistics_test.go
+++ b/internal/modules/adminstats/statistics_test.go
@@ -103,23 +103,80 @@ func TestParseStatisticsTimeseriesBucket(t *testing.T) {
 		t.Fatalf("value = %q, want %q", value, timeseriesBucketHour)
 	}
 
-	value, err = parseStatisticsTimeseriesBucket("day")
-	if err != nil {
-		t.Fatalf("parseStatisticsTimeseriesBucket returned error: %v", err)
-	}
-	if value != timeseriesBucketDay {
-		t.Fatalf("value = %q, want %q", value, timeseriesBucketDay)
+	for raw, want := range map[string]string{
+		"day":   timeseriesBucketDay,
+		"week":  timeseriesBucketWeek,
+		"month": timeseriesBucketMonth,
+	} {
+		value, err = parseStatisticsTimeseriesBucket(raw)
+		if err != nil {
+			t.Fatalf("parseStatisticsTimeseriesBucket(%q) returned error: %v", raw, err)
+		}
+		if value != want {
+			t.Fatalf("value = %q, want %q", value, want)
+		}
 	}
 
-	if _, err := parseStatisticsTimeseriesBucket("week"); err == nil {
+	if _, err := parseStatisticsTimeseriesBucket("year"); err == nil {
 		t.Fatalf("expected invalid bucket to fail")
+	}
+}
+
+func TestParseStatisticsTimezone(t *testing.T) {
+	tz, loc, err := parseStatisticsTimezone("")
+	if err != nil {
+		t.Fatalf("parseStatisticsTimezone(\"\") returned error: %v", err)
+	}
+	if tz != defaultStatisticsTimezone || loc != time.UTC {
+		t.Fatalf("default timezone = %q/%v, want %q/UTC", tz, loc, defaultStatisticsTimezone)
+	}
+
+	tz, loc, err = parseStatisticsTimezone("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("parseStatisticsTimezone returned error: %v", err)
+	}
+	if tz != "Asia/Shanghai" || loc.String() != "Asia/Shanghai" {
+		t.Fatalf("timezone = %q/%v, want Asia/Shanghai", tz, loc)
+	}
+
+	if _, _, err := parseStatisticsTimezone("Not/AZone"); err == nil {
+		t.Fatalf("expected invalid timezone to fail")
+	}
+}
+
+func TestTruncateStatisticsTimeByBucketTimezone(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	// 2026-06-22T01:00:00Z is 2026-06-22T09:00:00 +08:00, so the local day bucket
+	// starts at 2026-06-22T00:00:00+08:00 == 2026-06-21T16:00:00Z.
+	at := time.Date(2026, 6, 22, 1, 0, 0, 0, time.UTC)
+	got := truncateStatisticsTimeByBucket(at, timeseriesBucketDay, loc)
+	wantUnix := time.Date(2026, 6, 22, 0, 0, 0, 0, loc).Unix()
+	if got.Unix() != wantUnix {
+		t.Fatalf("day bucket unix = %d, want %d", got.Unix(), wantUnix)
+	}
+	if got.Unix() != time.Date(2026, 6, 21, 16, 0, 0, 0, time.UTC).Unix() {
+		t.Fatalf("local-midnight instant mismatch: %v", got.UTC())
+	}
+
+	// Weeks start on Monday. 2026-06-22 is a Monday in Shanghai.
+	week := truncateStatisticsTimeByBucket(at, timeseriesBucketWeek, loc)
+	if week.Weekday() != time.Monday || week.Day() != 22 {
+		t.Fatalf("week bucket = %v, want Monday 2026-06-22", week)
+	}
+
+	month := truncateStatisticsTimeByBucket(at, timeseriesBucketMonth, loc)
+	if month.Day() != 1 || month.Month() != time.June {
+		t.Fatalf("month bucket = %v, want 2026-06-01", month)
 	}
 }
 
 func TestAccumulateRegistrationTimeseriesFromUsers(t *testing.T) {
 	from := time.Date(2026, 3, 8, 10, 0, 0, 0, time.UTC)
 	to := from.Add(2 * time.Hour)
-	points := initializeTimeseriesPoints(from, to, timeseriesBucketHour)
+	points := initializeTimeseriesPoints(from, to, timeseriesBucketHour, time.UTC)
 	pointByTime := make(map[time.Time]*statisticsTimeseriesPoint, len(points))
 	for i := range points {
 		pointByTime[points[i].Time] = &points[i]
@@ -133,7 +190,7 @@ func TestAccumulateRegistrationTimeseriesFromUsers(t *testing.T) {
 		{CreatedAt: nil}, // historical users with null created_at should be ignored.
 	}
 
-	accumulateRegistrationTimeseriesFromUsers(rows, pointByTime, timeseriesBucketHour)
+	accumulateRegistrationTimeseriesFromUsers(rows, pointByTime, timeseriesBucketHour, time.UTC)
 
 	if pointByTime[from].Registrations != 1 {
 		t.Fatalf("first bucket registrations = %d, want 1", pointByTime[from].Registrations)
@@ -151,15 +208,19 @@ func TestAccumulateRegistrationTimeseriesFromUsers(t *testing.T) {
 func TestBuildStatisticsBucketExpressionSQL(t *testing.T) {
 	t.Parallel()
 
-	hourExpr, err := buildStatisticsBucketExpressionSQL(timeseriesBucketHour, "created_at")
+	hourExpr, err := buildStatisticsBucketExpressionSQL(timeseriesBucketHour, "created_at", "$3")
 	if err != nil {
 		t.Fatalf("buildStatisticsBucketExpressionSQL(hour) returned error: %v", err)
 	}
 	if !strings.Contains(hourExpr, "date_trunc('hour'") {
 		t.Fatalf("hour expression = %q, expected hour date_trunc", hourExpr)
 	}
+	// The timezone must be bound as a parameter and re-anchored, not inlined.
+	if !strings.Contains(hourExpr, "AT TIME ZONE $3) AT TIME ZONE $3") {
+		t.Fatalf("hour expression = %q, expected re-anchored tz placeholder", hourExpr)
+	}
 
-	dayExpr, err := buildStatisticsBucketExpressionSQL(timeseriesBucketDay, "upload_time")
+	dayExpr, err := buildStatisticsBucketExpressionSQL(timeseriesBucketDay, "upload_time", "$3")
 	if err != nil {
 		t.Fatalf("buildStatisticsBucketExpressionSQL(day) returned error: %v", err)
 	}
@@ -167,7 +228,15 @@ func TestBuildStatisticsBucketExpressionSQL(t *testing.T) {
 		t.Fatalf("day expression = %q, expected day date_trunc", dayExpr)
 	}
 
-	if _, err := buildStatisticsBucketExpressionSQL("minute", "created_at"); err == nil {
+	weekExpr, err := buildStatisticsBucketExpressionSQL(timeseriesBucketWeek, "upload_time", "$3")
+	if err != nil {
+		t.Fatalf("buildStatisticsBucketExpressionSQL(week) returned error: %v", err)
+	}
+	if !strings.Contains(weekExpr, "date_trunc('week'") {
+		t.Fatalf("week expression = %q, expected week date_trunc", weekExpr)
+	}
+
+	if _, err := buildStatisticsBucketExpressionSQL("minute", "created_at", "$3"); err == nil {
 		t.Fatalf("expected invalid bucket to fail")
 	}
 }

--- a/internal/modules/adminstats/statistics_timeseries_builder.go
+++ b/internal/modules/adminstats/statistics_timeseries_builder.go
@@ -8,8 +8,8 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-func buildStatisticsTimeseries(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, from, to time.Time, bucket string) (*statisticsTimeseriesResponse, error) {
-	points := initializeTimeseriesPoints(from, to, bucket)
+func buildStatisticsTimeseries(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, from, to time.Time, bucket, tz string, loc *time.Location) (*statisticsTimeseriesResponse, error) {
+	points := initializeTimeseriesPoints(from, to, bucket, loc)
 
 	db := apiHelper.DBManager.DB
 	var (
@@ -18,20 +18,20 @@ func buildStatisticsTimeseries(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiT
 		err                error
 	)
 	if sqlDB := db.SQLDB(); sqlDB != nil {
-		registrationCounts, err = queryRegistrationCountsRawSQL(ctx.Context(), sqlDB, from, to, bucket)
+		registrationCounts, err = queryRegistrationCountsRawSQL(ctx.Context(), sqlDB, from, to, bucket, tz)
 		if err != nil {
 			return nil, err
 		}
-		uploadCounts, err = queryUploadCountsRawSQL(ctx.Context(), sqlDB, from, to, bucket)
+		uploadCounts, err = queryUploadCountsRawSQL(ctx.Context(), sqlDB, from, to, bucket, tz)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		registrationCounts, err = queryRegistrationCountsFallback(ctx, apiHelper, from, to, bucket)
+		registrationCounts, err = queryRegistrationCountsFallback(ctx, apiHelper, from, to, bucket, loc)
 		if err != nil {
 			return nil, err
 		}
-		uploadCounts, err = queryUploadCountsFallback(ctx, apiHelper, from, to, bucket)
+		uploadCounts, err = queryUploadCountsFallback(ctx, apiHelper, from, to, bucket, loc)
 		if err != nil {
 			return nil, err
 		}
@@ -54,6 +54,7 @@ func buildStatisticsTimeseries(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiT
 		From:        from.UTC(),
 		To:          to.UTC(),
 		Bucket:      bucket,
+		Timezone:    tz,
 		Points:      points,
 	}
 	return resp, nil

--- a/internal/modules/adminstats/statistics_timeseries_helpers.go
+++ b/internal/modules/adminstats/statistics_timeseries_helpers.go
@@ -6,43 +6,60 @@ import (
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql"
 )
 
-func truncateStatisticsTimeByBucket(t time.Time, bucket string) time.Time {
-	t = t.UTC()
+// truncateStatisticsTimeByBucket aligns t to the start of its bucket in loc.
+// Buckets are anchored to local calendar boundaries (weeks start on Monday, to
+// match Postgres date_trunc('week', ...)), so the resulting instant matches the
+// bucket_unix produced by the SQL query for the same timezone.
+func truncateStatisticsTimeByBucket(t time.Time, bucket string, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.UTC
+	}
+	t = t.In(loc)
 	switch bucket {
 	case timeseriesBucketDay:
-		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+	case timeseriesBucketWeek:
+		day := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+		// Shift back to Monday: Go's Weekday() has Sunday=0, so map Monday=0.
+		offset := (int(day.Weekday()) + 6) % 7
+		return day.AddDate(0, 0, -offset)
+	case timeseriesBucketMonth:
+		return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, loc)
 	default:
-		return t.Truncate(time.Hour)
+		return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, loc)
 	}
 }
 
-func bucketStepDuration(bucket string) time.Duration {
+func nextStatisticsBucket(t time.Time, bucket string) time.Time {
 	switch bucket {
 	case timeseriesBucketDay:
-		return 24 * time.Hour
+		return t.AddDate(0, 0, 1)
+	case timeseriesBucketWeek:
+		return t.AddDate(0, 0, 7)
+	case timeseriesBucketMonth:
+		return t.AddDate(0, 1, 0)
 	default:
-		return time.Hour
+		return t.Add(time.Hour)
 	}
 }
 
-func initializeTimeseriesPoints(from, to time.Time, bucket string) []statisticsTimeseriesPoint {
-	step := bucketStepDuration(bucket)
-	start := truncateStatisticsTimeByBucket(from, bucket)
-	end := truncateStatisticsTimeByBucket(to, bucket)
+func initializeTimeseriesPoints(from, to time.Time, bucket string, loc *time.Location) []statisticsTimeseriesPoint {
+	start := truncateStatisticsTimeByBucket(from, bucket, loc)
+	end := truncateStatisticsTimeByBucket(to, bucket, loc)
 
-	points := make([]statisticsTimeseriesPoint, 0, int(end.Sub(start)/step)+1)
-	for ts := start; !ts.After(end); ts = ts.Add(step) {
+	points := make([]statisticsTimeseriesPoint, 0)
+	for ts := start; !ts.After(end); ts = nextStatisticsBucket(ts, bucket) {
 		points = append(points, statisticsTimeseriesPoint{Time: ts})
 	}
 	return points
 }
 
-func accumulateRegistrationTimeseriesFromUsers(rows []*postgresql.User, pointByTime map[time.Time]*statisticsTimeseriesPoint, bucket string) {
+func accumulateRegistrationTimeseriesFromUsers(rows []*postgresql.User, pointByTime map[time.Time]*statisticsTimeseriesPoint, bucket string, loc *time.Location) {
 	for _, row := range rows {
 		if row == nil || row.CreatedAt == nil {
 			continue
 		}
-		key := truncateStatisticsTimeByBucket(row.CreatedAt.UTC(), bucket)
+		key := truncateStatisticsTimeByBucket(*row.CreatedAt, bucket, loc)
 		if p, ok := pointByTime[key]; ok {
 			p.Registrations++
 		}

--- a/internal/modules/adminstats/statistics_timeseries_queries.go
+++ b/internal/modules/adminstats/statistics_timeseries_queries.go
@@ -19,19 +19,34 @@ type statisticsUploadBucketCount struct {
 	Failure int
 }
 
-func buildStatisticsBucketExpressionSQL(bucket, columnName string) (string, error) {
+// buildStatisticsBucketExpressionSQL builds a bucket-start expression aligned to
+// the given timezone. The column (a timestamptz) is converted to local wall time,
+// truncated to the bucket unit, then re-anchored to an absolute instant via the
+// second AT TIME ZONE so EXTRACT(EPOCH ...) matches truncateStatisticsTimeByBucket.
+// tzPlaceholder is a bound-parameter placeholder (e.g. "$3") to avoid injecting
+// the timezone string into the query text.
+func buildStatisticsBucketExpressionSQL(bucket, columnName, tzPlaceholder string) (string, error) {
+	var unit string
 	switch bucket {
 	case timeseriesBucketHour:
-		return fmt.Sprintf("date_trunc('hour', %s AT TIME ZONE 'UTC')", columnName), nil
+		unit = "hour"
 	case timeseriesBucketDay:
-		return fmt.Sprintf("date_trunc('day', %s AT TIME ZONE 'UTC')", columnName), nil
+		unit = "day"
+	case timeseriesBucketWeek:
+		unit = "week"
+	case timeseriesBucketMonth:
+		unit = "month"
 	default:
 		return "", fmt.Errorf("invalid bucket")
 	}
+	return fmt.Sprintf(
+		"date_trunc('%s', %s AT TIME ZONE %s) AT TIME ZONE %s",
+		unit, columnName, tzPlaceholder, tzPlaceholder,
+	), nil
 }
 
-func queryRegistrationCountsRawSQL(queryCtx context.Context, sqlDB *stdsql.DB, from, to time.Time, bucket string) (map[int64]int, error) {
-	bucketExpr, err := buildStatisticsBucketExpressionSQL(bucket, userSchema.FieldCreatedAt)
+func queryRegistrationCountsRawSQL(queryCtx context.Context, sqlDB *stdsql.DB, from, to time.Time, bucket, tz string) (map[int64]int, error) {
+	bucketExpr, err := buildStatisticsBucketExpressionSQL(bucket, userSchema.FieldCreatedAt, "$3")
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +58,7 @@ func queryRegistrationCountsRawSQL(queryCtx context.Context, sqlDB *stdsql.DB, f
 		userSchema.FieldCreatedAt,
 		userSchema.FieldCreatedAt,
 	)
-	rows, err := sqlDB.QueryContext(queryCtx, query, from.UTC(), to.UTC())
+	rows, err := sqlDB.QueryContext(queryCtx, query, from.UTC(), to.UTC(), tz)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +81,8 @@ func queryRegistrationCountsRawSQL(queryCtx context.Context, sqlDB *stdsql.DB, f
 	return counts, nil
 }
 
-func queryUploadCountsRawSQL(queryCtx context.Context, sqlDB *stdsql.DB, from, to time.Time, bucket string) (map[int64]statisticsUploadBucketCount, error) {
-	bucketExpr, err := buildStatisticsBucketExpressionSQL(bucket, uploadlog.FieldUploadTime)
+func queryUploadCountsRawSQL(queryCtx context.Context, sqlDB *stdsql.DB, from, to time.Time, bucket, tz string) (map[int64]statisticsUploadBucketCount, error) {
+	bucketExpr, err := buildStatisticsBucketExpressionSQL(bucket, uploadlog.FieldUploadTime, "$3")
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +94,7 @@ func queryUploadCountsRawSQL(queryCtx context.Context, sqlDB *stdsql.DB, from, t
 		uploadlog.FieldUploadTime,
 		uploadlog.FieldUploadTime,
 	)
-	rows, err := sqlDB.QueryContext(queryCtx, query, from.UTC(), to.UTC())
+	rows, err := sqlDB.QueryContext(queryCtx, query, from.UTC(), to.UTC(), tz)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +126,7 @@ func queryUploadCountsRawSQL(queryCtx context.Context, sqlDB *stdsql.DB, from, t
 	return counts, nil
 }
 
-func queryRegistrationCountsFallback(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, from, to time.Time, bucket string) (map[int64]int, error) {
+func queryRegistrationCountsFallback(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, from, to time.Time, bucket string, loc *time.Location) (map[int64]int, error) {
 	rows, err := apiHelper.DBManager.DB.User.Query().
 		Where(
 			userSchema.CreatedAtNotNil(),
@@ -128,13 +143,13 @@ func queryRegistrationCountsFallback(ctx fiber.Ctx, apiHelper *harukiAPIHelper.H
 		if row == nil || row.CreatedAt == nil {
 			continue
 		}
-		key := truncateStatisticsTimeByBucket(row.CreatedAt.UTC(), bucket).Unix()
+		key := truncateStatisticsTimeByBucket(*row.CreatedAt, bucket, loc).Unix()
 		counts[key]++
 	}
 	return counts, nil
 }
 
-func queryUploadCountsFallback(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, from, to time.Time, bucket string) (map[int64]statisticsUploadBucketCount, error) {
+func queryUploadCountsFallback(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, from, to time.Time, bucket string, loc *time.Location) (map[int64]statisticsUploadBucketCount, error) {
 	rows, err := apiHelper.DBManager.DB.UploadLog.Query().
 		Where(
 			uploadlog.UploadTimeGTE(from),
@@ -148,7 +163,7 @@ func queryUploadCountsFallback(ctx fiber.Ctx, apiHelper *harukiAPIHelper.HarukiT
 
 	counts := make(map[int64]statisticsUploadBucketCount)
 	for _, row := range rows {
-		key := truncateStatisticsTimeByBucket(row.UploadTime, bucket).Unix()
+		key := truncateStatisticsTimeByBucket(row.UploadTime, bucket, loc).Unix()
 		current := counts[key]
 		current.Total++
 		if row.Success {

--- a/internal/modules/adminstats/statistics_types.go
+++ b/internal/modules/adminstats/statistics_types.go
@@ -59,6 +59,7 @@ type statisticsTimeseriesResponse struct {
 	From        time.Time                   `json:"from"`
 	To          time.Time                   `json:"to"`
 	Bucket      string                      `json:"bucket"`
+	Timezone    string                      `json:"timezone"`
 	Points      []statisticsTimeseriesPoint `json:"points"`
 }
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	// Embed the IANA timezone database so time.LoadLocation works regardless of
+	// whether the host/container ships system zoneinfo (used by admin statistics
+	// timeseries bucketing).
+	_ "time/tzdata"
+
 	harukiBootstrap "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/bootstrap"
 
 	harukiConfig "github.com/Team-Haruki/Haruki-Toolbox-Backend/config"


### PR DESCRIPTION
## Problem

The admin statistics timeseries bucketed strictly by UTC (`date_trunc('day', col AT TIME ZONE 'UTC')`) with no way to pass a timezone. For a non-UTC viewer (e.g. UTC+8) each "day" was split at local 08:00, so the dashboard trend chart was misaligned with the local calendar. `from`/`to` were already honored — only bucket alignment was UTC-locked.

## Change

- **New `tz` query param** (IANA name, e.g. `Asia/Shanghai`) on `/api/admin/statistics/timeseries`. Empty/missing → `UTC`, so existing callers are unaffected.
- **Bucket on local calendar boundaries**: SQL now `date_trunc(unit, col AT TIME ZONE $3) AT TIME ZONE $3` — the second `AT TIME ZONE` re-anchors the local bucket start to a real instant so its epoch matches the Go-side point keys. The timezone is passed as a **bound parameter** (`$3`), never string-interpolated.
- **Go-side bucketing made tz-aware** (point initialization + non-SQL fallback): `time.Date(..., loc)`, Monday-start weeks, calendar months, DST-safe stepping — kept in lockstep with the SQL.
- **Added `week` and `month` buckets** (previously only `hour`/`day`).
- **Embed `time/tzdata`** so `time.LoadLocation` works regardless of host/container zoneinfo.
- Response now echoes the resolved `timezone`.

No data migration needed — bucketing is computed at query time, so this fixes historical data too.

## Testing

- `go build . ./internal/...`
- `go test ./internal/modules/adminstats/` (added coverage: tz parsing, tz-aware day/week-Monday/month bucketing, week SQL expression, re-anchored `$3` placeholder)

## Frontend counterpart

The toolbox dashboard sends `tz: Intl.DateTimeFormat().resolvedOptions().timeZone` and exposes day/week/month + range selectors (separate repo, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)