### PR TITLE
[Fix] Bound serving reads and add inherit breaker + profiling

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -52,6 +52,9 @@ func normalizeConfigDefaults(cfg *Config) error {
 	if cfg.Backend.ShutdownTimeout <= 0 {
 		cfg.Backend.ShutdownTimeout = 10
 	}
+	if cfg.Backend.ProfilingIntervalSeconds <= 0 {
+		cfg.Backend.ProfilingIntervalSeconds = 15
+	}
 	if cfg.UserSystem.SMTP.TimeoutSeconds <= 0 {
 		cfg.UserSystem.SMTP.TimeoutSeconds = 10
 	}

--- a/config/env.go
+++ b/config/env.go
@@ -138,6 +138,12 @@ func applyEnvOverrides(cfg *Config) error {
 	overrideString(&cfg.Backend.ProxyHeader, "BACKEND_PROXY_HEADER")
 	overrideString(&cfg.Backend.BackendURL, "BACKEND_URL", "BACKEND_PUBLIC_BASE_URL")
 	overrideString(&cfg.Backend.BackendCDNURL, "BACKEND_CDN_URL")
+	if err := overrideBool(&cfg.Backend.ProfilingEnabled, "BACKEND_PROFILING_ENABLED"); err != nil {
+		return err
+	}
+	if err := overrideInt(&cfg.Backend.ProfilingIntervalSeconds, "BACKEND_PROFILING_INTERVAL_SECONDS"); err != nil {
+		return err
+	}
 
 	overrideString(&cfg.OAuth2.Provider, "OAUTH2_PROVIDER")
 	overrideString(&cfg.OAuth2.HydraPublicURL, "HYDRA_PUBLIC_URL", "HYDRA_PUBLIC_BASE_URL")

--- a/config/types.go
+++ b/config/types.go
@@ -110,6 +110,12 @@ type BackendConfig struct {
 	ProxyHeader      string   `yaml:"proxy_header"`
 	BackendURL       string   `yaml:"backend_url"`
 	BackendCDNURL    string   `yaml:"backend_cdn_url"`
+	// ProfilingEnabled turns on opt-in performance instrumentation: a periodic
+	// Mongo/PG pool + Go GC stats sampler and slow-request autopsies. Off by default;
+	// safe to flip on during an incident to diagnose resource saturation.
+	ProfilingEnabled bool `yaml:"profiling_enabled"`
+	// ProfilingIntervalSeconds is how often the stats sampler logs (default 15s).
+	ProfilingIntervalSeconds int `yaml:"profiling_interval_seconds"`
 }
 
 type SMTPConfig struct {

--- a/haruki-toolbox-configs.example.yaml
+++ b/haruki-toolbox-configs.example.yaml
@@ -98,6 +98,13 @@ backend:
     - "100.64.0.0/10"
     - "10.0.0.0/8"
   proxy_header: "X-Forwarded-For"
+  # Opt-in performance instrumentation. When true, the backend attaches a MongoDB
+  # pool monitor and periodically logs Mongo pool / PostgreSQL pool / Go GC stats,
+  # and logs a per-stage autopsy for box reads slower than 500ms. Off by default;
+  # safe to enable during an incident to diagnose resource saturation. Env overrides:
+  # BACKEND_PROFILING_ENABLED, BACKEND_PROFILING_INTERVAL_SECONDS.
+  profiling_enabled: false
+  profiling_interval_seconds: 15
 
 third_party_data_provider:
   endpoint_8823: ""

--- a/internal/bootstrap/database.go
+++ b/internal/bootstrap/database.go
@@ -1,0 +1,24 @@
+package bootstrap
+
+import (
+	"database/sql"
+	"time"
+)
+
+// openTunedSQLDB opens a database/sql pool with explicit sizing. Ent's generated
+// Open leaves the database/sql defaults in place (MaxOpenConns=0 → unlimited, which
+// can exhaust the server's max_connections; MaxIdleConns=2 → connection churn under
+// load), so we open the pool ourselves and wrap it in the Ent driver at the call
+// site. ConnMaxLifetime recycles connections so a PG restart or a proxy in front of
+// PG does not leave stale connections in the pool.
+func openTunedSQLDB(driverName, dataSourceName string, maxOpen, maxIdle int) (*sql.DB, error) {
+	db, err := sql.Open(driverName, dataSourceName)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(maxOpen)
+	db.SetMaxIdleConns(maxIdle)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetConnMaxIdleTime(5 * time.Minute)
+	return db, nil
+}

--- a/internal/bootstrap/run.go
+++ b/internal/bootstrap/run.go
@@ -2,6 +2,8 @@ package bootstrap
 
 import (
 	"context"
+	"database/sql"
+	entsql "entgo.io/ent/dialect/sql"
 	"errors"
 	"fmt"
 	harukiAPI "github.com/Team-Haruki/Haruki-Toolbox-Backend/api"
@@ -14,6 +16,7 @@ import (
 	harukiRedis "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/redis"
 	harukiHandler "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/handler"
 	harukiLogger "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/logger"
+	perfdebug "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/perfdebug"
 	harukiSekaiAPIClient "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/sekaiapi"
 	harukiSMTP "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/smtp"
 	harukiVersion "github.com/Team-Haruki/Haruki-Toolbox-Backend/version"
@@ -55,6 +58,7 @@ func Run(cfg harukiConfig.Config) error {
 	// Set global log level and file writer for NewLoggerFromGlobal
 	harukiLogger.SetGlobalLogLevel(cfg.Backend.LogLevel)
 	harukiLogger.SetGlobalFileWriter(loggerWriter)
+	perfdebug.SetEnabled(cfg.Backend.ProfilingEnabled)
 
 	mainLogger := harukiLogger.NewLogger("Main", cfg.Backend.LogLevel, loggerWriter)
 	mainLogger.Infof("%s", fmt.Sprintf("========================= Haruki Toolbox Backend %s =========================", harukiVersion.Version))
@@ -62,6 +66,14 @@ func Run(cfg harukiConfig.Config) error {
 	mainLogger.Infof("Powered By Haruki Dev Team")
 
 	sekaiAPIClient := harukiSekaiAPIClient.NewHarukiSekaiAPIClient(cfg.SekaiAPI.APIEndpoint, cfg.SekaiAPI.APIToken)
+	// When profiling is enabled, attach a pool monitor so the stats sampler can
+	// observe client-side checkout waits (invisible to Mongo's server-side slow log).
+	var mongoPoolStats *harukiMongo.PoolStats
+	var mongoOpts []harukiMongo.MongoOption
+	if cfg.Backend.ProfilingEnabled {
+		mongoPoolStats = harukiMongo.NewPoolStats()
+		mongoOpts = append(mongoOpts, harukiMongo.WithPoolMonitor(mongoPoolStats.Monitor()))
+	}
 	mongoCtx, cancelMongoInit := startupContext()
 	mongoManager, err := harukiMongo.NewMongoDBManager(
 		mongoCtx,
@@ -69,6 +81,7 @@ func Run(cfg harukiConfig.Config) error {
 		cfg.MongoDB.DB,
 		cfg.MongoDB.Suite,
 		cfg.MongoDB.Mysekai,
+		mongoOpts...,
 	)
 	cancelMongoInit()
 	if err != nil {
@@ -90,10 +103,11 @@ func Run(cfg harukiConfig.Config) error {
 		return fmt.Errorf("init Redis: %w", err)
 	}
 	cancelRedisInit()
-	entClient, err := dbManager.Open(cfg.UserSystem.DBType, cfg.UserSystem.DBURL)
+	entSQLDB, err := openTunedSQLDB(cfg.UserSystem.DBType, cfg.UserSystem.DBURL, 50, 10)
 	if err != nil {
 		return fmt.Errorf("init PostgreSQL: %w", err)
 	}
+	entClient := dbManager.NewClient(dbManager.Driver(entsql.OpenDB(cfg.UserSystem.DBType, entSQLDB)))
 	defer func() {
 		_ = entClient.Close()
 	}()
@@ -170,11 +184,14 @@ func Run(cfg harukiConfig.Config) error {
 	}()
 
 	dbMgr := harukiDatabaseManager.NewHarukiToolboxDBManager(entClient, redisClient, mongoManager)
+	var botStatsDB *sql.DB
 	if botDBURL := strings.TrimSpace(cfg.HarukiBot.DBURL); botDBURL != "" {
-		botClient, botErr := neopgManager.Open(cfg.UserSystem.DBType, botDBURL)
+		botSQLDB, botErr := openTunedSQLDB(cfg.UserSystem.DBType, botDBURL, 20, 5)
 		if botErr != nil {
 			return fmt.Errorf("init Bot PostgreSQL: %w", botErr)
 		}
+		botStatsDB = botSQLDB
+		botClient := neopgManager.NewClient(neopgManager.Driver(entsql.OpenDB(cfg.UserSystem.DBType, botSQLDB)))
 		defer func() {
 			_ = botClient.Close()
 		}()
@@ -210,12 +227,22 @@ func Run(cfg harukiConfig.Config) error {
 	harukiAPI.RegisterRoutes(apiHelper)
 	schedulerCtx, stopSchedulers := context.WithCancel(context.Background())
 	waitAfdianScheduler := startAfdianSponsorSyncScheduler(schedulerCtx, entClient, cfg.Afdian, mainLogger)
-	// Cancel then drain the scheduler goroutine before the deferred entClient.Close
-	// runs, so an in-flight sync never uses the client after it is closed. Both
+	waitStatsSampler := func() {}
+	if cfg.Backend.ProfilingEnabled {
+		sqlPools := []sqlPoolSource{{name: "toolbox", db: entSQLDB}}
+		if botStatsDB != nil {
+			sqlPools = append(sqlPools, sqlPoolSource{name: "bot", db: botStatsDB})
+		}
+		samplerInterval := time.Duration(cfg.Backend.ProfilingIntervalSeconds) * time.Second
+		waitStatsSampler = startStatsSampler(schedulerCtx, samplerInterval, mongoPoolStats, sqlPools, mainLogger)
+	}
+	// Cancel then drain the scheduler goroutines before the deferred entClient.Close
+	// runs, so an in-flight sync/sampler never uses the client after it is closed. All
 	// calls are idempotent, so the explicit shutdown path below can repeat them.
 	stopAndWaitSchedulers := func() {
 		stopSchedulers()
 		waitAfdianScheduler()
+		waitStatsSampler()
 	}
 	defer stopAndWaitSchedulers()
 	loadedRegions, failedRegions := harukiHandler.GetSuiteRestorerLoadStatus()

--- a/internal/bootstrap/stats_sampler.go
+++ b/internal/bootstrap/stats_sampler.go
@@ -1,0 +1,89 @@
+package bootstrap
+
+import (
+	"context"
+	"database/sql"
+	"runtime"
+	"sync"
+	"time"
+
+	harukiMongo "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/mongo"
+	harukiLogger "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/logger"
+)
+
+const defaultProfilingInterval = 15 * time.Second
+
+// sqlPoolSource pairs a labeled name with a *sql.DB so the sampler can log each
+// pool's database/sql stats. The Ent client does not re-expose the underlying
+// *sql.DB, so bootstrap retains the handles returned by openTunedSQLDB.
+type sqlPoolSource struct {
+	name string
+	db   *sql.DB
+}
+
+// startStatsSampler launches a background goroutine that periodically logs Mongo
+// connection-pool telemetry, database/sql pool stats, and Go runtime/GC stats. It
+// mirrors the afdian scheduler's lifecycle: cancel ctx then call the returned wait
+// before closing the DB handles it samples, so it never touches a closed pool.
+// poolStats may be nil (Mongo telemetry omitted). It is only started when profiling
+// is enabled.
+func startStatsSampler(ctx context.Context, interval time.Duration, poolStats *harukiMongo.PoolStats, sqlPools []sqlPoolSource, logger *harukiLogger.Logger) func() {
+	if interval <= 0 {
+		interval = defaultProfilingInterval
+	}
+	logger.Infof("profiling stats sampler enabled with interval %s", interval)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		var mem runtime.MemStats
+		var lastNumGC uint32
+		var lastPauseTotal uint64
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Infof("profiling stats sampler stopped")
+				return
+			case <-ticker.C:
+				sampleStats(poolStats, sqlPools, logger, &mem, &lastNumGC, &lastPauseTotal)
+			}
+		}
+	}()
+	return wg.Wait
+}
+
+func sampleStats(poolStats *harukiMongo.PoolStats, sqlPools []sqlPoolSource, logger *harukiLogger.Logger, mem *runtime.MemStats, lastNumGC *uint32, lastPauseTotal *uint64) {
+	if poolStats != nil {
+		s := poolStats.Snapshot()
+		logger.Infof("mongo pool: checkedOut=%d pending=%d checkouts=%d failures=%d meanWait=%s maxWait=%s created=%d closed=%d",
+			s.CheckedOut, s.Pending, s.Checkouts, s.CheckoutFailures,
+			s.MeanWait.Round(time.Microsecond), s.MaxWait.Round(time.Microsecond), s.Created, s.Closed)
+	}
+
+	for _, p := range sqlPools {
+		if p.db == nil {
+			continue
+		}
+		st := p.db.Stats()
+		logger.Infof("pg pool[%s]: open=%d/%d inUse=%d idle=%d waitCount=%d waitDuration=%s maxIdleClosed=%d maxLifetimeClosed=%d",
+			p.name, st.OpenConnections, st.MaxOpenConnections, st.InUse, st.Idle,
+			st.WaitCount, st.WaitDuration.Round(time.Millisecond), st.MaxIdleTimeClosed, st.MaxLifetimeClosed)
+	}
+
+	runtime.ReadMemStats(mem)
+	gcDelta := mem.NumGC - *lastNumGC
+	pauseDelta := mem.PauseTotalNs - *lastPauseTotal
+	*lastNumGC = mem.NumGC
+	*lastPauseTotal = mem.PauseTotalNs
+	var meanPause time.Duration
+	if gcDelta > 0 {
+		meanPause = time.Duration(pauseDelta / uint64(gcDelta))
+	}
+	logger.Infof("runtime: goroutines=%d heapInUse=%dMiB heapObjects=%d gcCycles=%d meanGCPause=%s nextGC=%dMiB",
+		runtime.NumGoroutine(), mem.HeapInuse/(1024*1024), mem.HeapObjects,
+		gcDelta, meanPause.Round(time.Microsecond), mem.NextGC/(1024*1024))
+}

--- a/internal/modules/upload/inherit.go
+++ b/internal/modules/upload/inherit.go
@@ -6,6 +6,7 @@ import (
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
 	harukiSekai "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/sekai"
+	"strconv"
 
 	"github.com/gofiber/fiber/v3"
 )
@@ -27,8 +28,38 @@ func handleInheritSubmit(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers) 
 		if err := c.Bind().Body(data); err != nil {
 			return harukiAPIHelper.ErrorBadRequest(c, "invalid request payload")
 		}
+		// Fast-fail when the game API for this server is already degraded, so we stop
+		// hammering a failing upstream and the caller learns immediately instead of
+		// blocking for the full ~90s run cap.
+		allowed, retryAfter, breakerToken := inheritBreaker.Allow(server)
+		if !allowed {
+			c.Set("Retry-After", strconv.Itoa(retryAfterSeconds(retryAfter)))
+			return harukiAPIHelper.UpdatedDataResponse[string](c, fiber.StatusServiceUnavailable, "game server temporarily degraded, please retry later", nil)
+		}
+		// Bound concurrent inherits per server; overflow fast-fails rather than
+		// piling up slow goroutines against one game server. Release the breaker probe
+		// permit (if this admission was a half-open probe) since we never touched the
+		// upstream.
+		if !inheritLimiter.acquire(server) {
+			inheritBreaker.ReleaseProbe(server, breakerToken)
+			c.Set("Retry-After", strconv.Itoa(retryAfterSeconds(inheritBreakerRetryAfterFloor)))
+			return harukiAPIHelper.UpdatedDataResponse[string](c, fiber.StatusTooManyRequests, "too many concurrent inherit requests, please retry later", nil)
+		}
+		defer inheritLimiter.release(server)
+		// Guarantee the breaker epoch is resolved even if retriever.Run panics (which
+		// would otherwise leak a half-open probe). Default to degraded; the normal path
+		// below overwrites it with the real verdict and marks it recorded. RecordResult
+		// ignores a stale token, so the deferred call is a harmless no-op afterwards.
+		breakerRecorded := false
+		defer func() {
+			if !breakerRecorded {
+				inheritBreaker.RecordResult(server, breakerToken, true)
+			}
+		}()
 		retriever := harukiSekai.NewSekaiDataRetriever(server, *data, uploadType)
 		result, err := retriever.Run(ctx)
+		inheritBreaker.RecordResult(server, breakerToken, inheritFailureIsUpstreamDegradation(err))
+		breakerRecorded = true
 		if err != nil {
 			uploadServer := harukiUtils.SupportedDataUploadServer(server)
 			recordInheritRetrievalFailure(apiHelper, uploadServer, uploadType, result, err)

--- a/internal/modules/upload/inherit_breaker.go
+++ b/internal/modules/upload/inherit_breaker.go
@@ -1,0 +1,312 @@
+package upload
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
+	harukiSekai "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/sekai"
+)
+
+// Inherit runs are slow (~30-90s) and hammer a single game server sequentially. Two
+// per-server gates protect both the backend and the upstream game API without
+// changing the synchronous client contract:
+//
+//   - a bounded concurrency limiter caps how many inherits run against one server at
+//     once, fast-failing the overflow with 429 instead of piling up slow goroutines;
+//   - a circuit breaker trips when the game API for a server is degraded (timeouts /
+//     5xx / 429 / maintenance), fast-failing new inherits with 503 for a cooldown so
+//     we stop hammering a server that is already failing.
+//
+// Both are keyed per server so a degraded JP does not starve or trip EN/TW/KR/CN.
+const (
+	inheritMaxConcurrentPerServer  = 8
+	inheritBreakerFailureThreshold = 5
+	inheritBreakerWindow           = 60 * time.Second
+	inheritBreakerCooldown         = 30 * time.Second
+	// inheritBreakerRetryAfterFloor is the minimum Retry-After advertised while open.
+	inheritBreakerRetryAfterFloor = 1 * time.Second
+)
+
+// inheritFailureIsUpstreamDegradation reports whether an inherit failure signals a
+// degraded/unavailable game API (which should trip the breaker) as opposed to a user
+// or client error (bad inherit credentials, incomplete tutorial, not found), which
+// means the upstream answered fine and must NOT trip it.
+func inheritFailureIsUpstreamDegradation(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Timeout/cancellation from a per-call (15s) or the whole-run (90s) deadline: the
+	// upstream hung. This is the dominant degradation signal seen in production
+	// (context deadline exceeded).
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	// Explicit maintenance means the feature/server is unavailable upstream.
+	if harukiSekai.IsMaintenanceError(err) {
+		return true
+	}
+	// Game-API 5xx and 429 are degradation; 4xx (bad credentials, forbidden, not
+	// found) are user/client errors and must not trip the breaker. StatusCode 0 means
+	// the request never received an HTTP response — a transport-level failure
+	// (connection refused, TLS handshake error, reset, DNS failure, EOF), which the
+	// callAPI helper reports as APIError{StatusCode: 0}; a hard-down upstream is
+	// degradation.
+	var apiErr *harukiSekai.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.StatusCode == 0 || apiErr.StatusCode >= 500 || apiErr.StatusCode == 429 {
+			return true
+		}
+		if apiErr.StatusCode >= 400 && apiErr.StatusCode < 500 {
+			return false
+		}
+	}
+	// A transport-level timeout that did not surface as context.DeadlineExceeded.
+	var timeoutErr interface{ Timeout() bool }
+	if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
+		return true
+	}
+	return false
+}
+
+// inheritConcurrencyLimiter bounds concurrent inherits per server with a
+// non-blocking acquire: when a server's slots are full the caller is rejected
+// immediately rather than queued.
+type inheritConcurrencyLimiter struct {
+	mu       sync.Mutex
+	capacity int
+	servers  map[harukiUtils.SupportedInheritUploadServer]chan struct{}
+}
+
+func newInheritConcurrencyLimiter(capacity int) *inheritConcurrencyLimiter {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &inheritConcurrencyLimiter{
+		capacity: capacity,
+		servers:  make(map[harukiUtils.SupportedInheritUploadServer]chan struct{}),
+	}
+}
+
+func (l *inheritConcurrencyLimiter) slots(server harukiUtils.SupportedInheritUploadServer) chan struct{} {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	ch, ok := l.servers[server]
+	if !ok {
+		ch = make(chan struct{}, l.capacity)
+		l.servers[server] = ch
+	}
+	return ch
+}
+
+// acquire takes a slot for server without blocking, returning false when full.
+func (l *inheritConcurrencyLimiter) acquire(server harukiUtils.SupportedInheritUploadServer) bool {
+	select {
+	case l.slots(server) <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// release returns a previously acquired slot. It is a no-op if none is held.
+func (l *inheritConcurrencyLimiter) release(server harukiUtils.SupportedInheritUploadServer) {
+	select {
+	case <-l.slots(server):
+	default:
+	}
+}
+
+type breakerPhase int
+
+const (
+	breakerClosed breakerPhase = iota
+	breakerOpen
+	breakerHalfOpen
+)
+
+type breakerState struct {
+	phase    breakerPhase
+	failures []time.Time
+	openedAt time.Time
+	// gen is bumped on every phase transition. Allow tags each admission with the gen
+	// at admit time; RecordResult/ReleaseProbe ignore results whose token no longer
+	// matches. This is what stops a slow request admitted in one epoch from mutating a
+	// later epoch's state (e.g. a straggler success re-closing an open breaker, or a
+	// straggler failure disrupting a fresh half-open probe).
+	gen uint64
+	// probePending marks that a half-open probe has been admitted and awaits its
+	// result, so concurrent callers are rejected while it is in flight.
+	probePending bool
+}
+
+// inheritCircuitBreaker is a per-server circuit breaker. It is closed normally,
+// trips open after `threshold` degradation failures within `window`, rejects while
+// open for `cooldown`, then admits a single probe (half-open) whose result closes or
+// re-opens it. The clock is injectable for deterministic tests.
+type inheritCircuitBreaker struct {
+	mu        sync.Mutex
+	threshold int
+	window    time.Duration
+	cooldown  time.Duration
+	now       func() time.Time
+	servers   map[harukiUtils.SupportedInheritUploadServer]*breakerState
+}
+
+func newInheritCircuitBreaker(threshold int, window, cooldown time.Duration) *inheritCircuitBreaker {
+	if threshold <= 0 {
+		threshold = 1
+	}
+	return &inheritCircuitBreaker{
+		threshold: threshold,
+		window:    window,
+		cooldown:  cooldown,
+		now:       time.Now,
+		servers:   make(map[harukiUtils.SupportedInheritUploadServer]*breakerState),
+	}
+}
+
+func (b *inheritCircuitBreaker) stateFor(server harukiUtils.SupportedInheritUploadServer) *breakerState {
+	st, ok := b.servers[server]
+	if !ok {
+		st = &breakerState{phase: breakerClosed}
+		b.servers[server] = st
+	}
+	return st
+}
+
+// Allow reports whether an inherit for server may proceed. When it returns false the
+// second value is a suggested Retry-After. The third value is a token that a caller
+// admitted (first value true) MUST pass to exactly one of RecordResult or
+// ReleaseProbe so the epoch is resolved correctly; the token is 0 and meaningless
+// when the request is rejected.
+func (b *inheritCircuitBreaker) Allow(server harukiUtils.SupportedInheritUploadServer) (bool, time.Duration, uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	st := b.stateFor(server)
+	now := b.now()
+	switch st.phase {
+	case breakerClosed:
+		return true, 0, st.gen
+	case breakerOpen:
+		elapsed := now.Sub(st.openedAt)
+		if elapsed < b.cooldown {
+			return false, retryAfterFor(b.cooldown - elapsed), 0
+		}
+		// Cooldown elapsed: transition to half-open and admit a single probe.
+		st.phase = breakerHalfOpen
+		st.gen++
+		st.probePending = true
+		return true, 0, st.gen
+	case breakerHalfOpen:
+		if st.probePending {
+			return false, retryAfterFor(b.cooldown), 0
+		}
+		// A prior probe was released without a verdict; admit a new probe in the same
+		// epoch (no transition, so the gen is unchanged).
+		st.probePending = true
+		return true, 0, st.gen
+	default:
+		return true, 0, st.gen
+	}
+}
+
+// ReleaseProbe undoes a half-open probe permit granted by Allow when the caller could
+// not actually exercise the upstream (e.g. it was rejected by a downstream local
+// gate). It records no health verdict, so a legitimately open/half-open breaker is
+// not prematurely closed; the next admitted request probes again. A stale token
+// (from a prior epoch) is ignored.
+func (b *inheritCircuitBreaker) ReleaseProbe(server harukiUtils.SupportedInheritUploadServer, token uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	st := b.stateFor(server)
+	if token != st.gen {
+		return
+	}
+	if st.phase == breakerHalfOpen {
+		st.probePending = false
+	}
+}
+
+// RecordResult feeds an inherit outcome back to the breaker. token is the value Allow
+// returned for this admission; degraded must be the result of
+// inheritFailureIsUpstreamDegradation on the run error (false on success or on a user
+// error, both of which prove the upstream is healthy). A result whose token no longer
+// matches the current epoch is a straggler and is ignored.
+func (b *inheritCircuitBreaker) RecordResult(server harukiUtils.SupportedInheritUploadServer, token uint64, degraded bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	st := b.stateFor(server)
+	now := b.now()
+	if token != st.gen {
+		// Straggler admitted before a later phase transition: its outcome says nothing
+		// about the current epoch, so ignore it. This prevents a slow success admitted
+		// before the trip from re-closing an open breaker, and a slow failure from
+		// disrupting a fresh half-open probe.
+		return
+	}
+
+	switch st.phase {
+	case breakerHalfOpen:
+		st.probePending = false
+		st.gen++
+		if degraded {
+			// Probe failed: re-open for another cooldown.
+			st.phase = breakerOpen
+			st.openedAt = now
+		} else {
+			st.phase = breakerClosed
+		}
+		st.failures = nil
+	case breakerClosed:
+		if !degraded {
+			st.failures = nil
+			return
+		}
+		st.failures = append(pruneBefore(st.failures, now.Add(-b.window)), now)
+		if len(st.failures) >= b.threshold {
+			st.phase = breakerOpen
+			st.openedAt = now
+			st.gen++
+			st.failures = nil
+		}
+	case breakerOpen:
+		// A current-epoch result while open should not occur (admissions in this epoch
+		// are Closed or HalfOpen); ignore defensively so the cooldown is not disturbed.
+	}
+}
+
+// pruneBefore drops timestamps at or before cutoff, keeping the slice's order.
+func pruneBefore(ts []time.Time, cutoff time.Time) []time.Time {
+	kept := ts[:0]
+	for _, t := range ts {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	return kept
+}
+
+func retryAfterFor(d time.Duration) time.Duration {
+	if d < inheritBreakerRetryAfterFloor {
+		return inheritBreakerRetryAfterFloor
+	}
+	return d
+}
+
+// retryAfterSeconds renders a Retry-After header value: whole seconds, rounded up,
+// never below 1.
+func retryAfterSeconds(d time.Duration) int {
+	secs := int((d + time.Second - 1) / time.Second)
+	if secs < 1 {
+		return 1
+	}
+	return secs
+}
+
+var (
+	inheritLimiter = newInheritConcurrencyLimiter(inheritMaxConcurrentPerServer)
+	inheritBreaker = newInheritCircuitBreaker(inheritBreakerFailureThreshold, inheritBreakerWindow, inheritBreakerCooldown)
+)

--- a/internal/modules/upload/inherit_breaker_test.go
+++ b/internal/modules/upload/inherit_breaker_test.go
@@ -1,0 +1,239 @@
+package upload
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
+	harukiSekai "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/sekai"
+)
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string { return "i/o timeout" }
+func (timeoutError) Timeout() bool { return true }
+
+func TestInheritFailureIsUpstreamDegradation(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not degradation", nil, false},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"deadline wrapped in retrieval error", harukiSekai.NewDataRetrievalError("run", "init", "client init failed", context.DeadlineExceeded), true},
+		{"canceled", context.Canceled, true},
+		{"maintenance", harukiSekai.ErrMaintenance, true},
+		{"maintenance wrapped", harukiSekai.NewDataRetrievalError("mysekai", "check", "maintenance", harukiSekai.ErrMaintenance), true},
+		{"api 500", harukiSekai.NewAPIError("/suite", "GET", 500, "boom", nil), true},
+		{"api 503 wrapped", harukiSekai.NewDataRetrievalError("suite", "fetch", "unavailable", harukiSekai.NewAPIError("/suite", "GET", 503, "unavailable", nil)), true},
+		{"api 429", harukiSekai.NewAPIError("/user", "PUT", 429, "slow down", nil), true},
+		{"api 403 is user error", harukiSekai.NewAPIError("/inherit", "POST", 403, "forbidden", nil), false},
+		{"api 400 wrapped is user error", harukiSekai.NewDataRetrievalError("run", "init", "bad creds", harukiSekai.NewAPIError("/inherit", "POST", 400, "bad", nil)), false},
+		{"api 404 is user error", harukiSekai.NewAPIError("/user", "GET", 404, "missing", nil), false},
+		{"net timeout without status", timeoutError{}, true},
+		{"api zero-status wrapping timeout", harukiSekai.NewAPIError("/user", "GET", 0, "conn", timeoutError{}), true},
+		// StatusCode 0 == transport failure (no HTTP response): a hard-down upstream
+		// like connection-refused is degradation and must trip the breaker.
+		{"api zero-status transport failure", harukiSekai.NewAPIError("/user", "GET", 0, "conn", errors.New("connection refused")), true},
+		{"plain error is not degradation", errors.New("some parse error"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := inheritFailureIsUpstreamDegradation(tc.err); got != tc.want {
+				t.Fatalf("inheritFailureIsUpstreamDegradation(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+const testServer = harukiUtils.SupportedInheritUploadServer("jp")
+
+// newTestBreaker returns a breaker whose clock is driven by the returned pointer, so
+// tests advance time deterministically.
+func newTestBreaker(threshold int, window, cooldown time.Duration) (*inheritCircuitBreaker, *time.Time) {
+	b := newInheritCircuitBreaker(threshold, window, cooldown)
+	now := time.Unix(1_700_000_000, 0)
+	b.now = func() time.Time { return now }
+	return b, &now
+}
+
+// admit calls Allow, asserts it was permitted, and returns the epoch token the caller
+// must feed back to RecordResult/ReleaseProbe.
+func admit(t *testing.T, b *inheritCircuitBreaker, server harukiUtils.SupportedInheritUploadServer) uint64 {
+	t.Helper()
+	allowed, _, token := b.Allow(server)
+	if !allowed {
+		t.Fatalf("expected Allow to permit request")
+	}
+	return token
+}
+
+func mustReject(t *testing.T, b *inheritCircuitBreaker, server harukiUtils.SupportedInheritUploadServer) time.Duration {
+	t.Helper()
+	allowed, retryAfter, _ := b.Allow(server)
+	if allowed {
+		t.Fatalf("expected Allow to reject request")
+	}
+	if retryAfter < inheritBreakerRetryAfterFloor {
+		t.Fatalf("retryAfter %s below floor %s", retryAfter, inheritBreakerRetryAfterFloor)
+	}
+	return retryAfter
+}
+
+func TestBreakerTripsAfterThreshold(t *testing.T) {
+	b, _ := newTestBreaker(3, time.Minute, 30*time.Second)
+	// Two degradations: still below threshold, still closed.
+	for i := 0; i < 2; i++ {
+		b.RecordResult(testServer, admit(t, b, testServer), true)
+	}
+	// Third degradation trips it.
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	mustReject(t, b, testServer)
+}
+
+func TestBreakerSuccessResetsFailures(t *testing.T) {
+	b, _ := newTestBreaker(3, time.Minute, 30*time.Second)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	// A success clears accumulated failures, so two more degradations do not trip.
+	b.RecordResult(testServer, admit(t, b, testServer), false)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	admit(t, b, testServer) // still closed
+}
+
+func TestBreakerWindowPrunesOldFailures(t *testing.T) {
+	b, now := newTestBreaker(3, time.Minute, 30*time.Second)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	// Advance beyond the window so the earlier two failures no longer count.
+	*now = now.Add(2 * time.Minute)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	// Only two failures fall within the window → still closed.
+	admit(t, b, testServer)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	// Now three within the window → tripped.
+	mustReject(t, b, testServer)
+}
+
+func TestBreakerHalfOpenProbeSuccessCloses(t *testing.T) {
+	b, now := newTestBreaker(1, time.Minute, 30*time.Second)
+	b.RecordResult(testServer, admit(t, b, testServer), true) // trips (threshold 1)
+	mustReject(t, b, testServer)
+	// After cooldown a single probe is admitted.
+	*now = now.Add(31 * time.Second)
+	probe := admit(t, b, testServer)
+	// A concurrent second request while the probe is in flight is rejected.
+	mustReject(t, b, testServer)
+	// Probe succeeds → closed, normal traffic resumes.
+	b.RecordResult(testServer, probe, false)
+	admit(t, b, testServer)
+}
+
+func TestBreakerHalfOpenProbeFailureReopens(t *testing.T) {
+	b, now := newTestBreaker(1, time.Minute, 30*time.Second)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	*now = now.Add(31 * time.Second)
+	probe := admit(t, b, testServer) // probe admitted
+	b.RecordResult(testServer, probe, true)
+	// Probe failed → re-open, reject again until the next cooldown.
+	mustReject(t, b, testServer)
+	*now = now.Add(31 * time.Second)
+	admit(t, b, testServer)
+}
+
+func TestBreakerReleaseProbeDoesNotClose(t *testing.T) {
+	b, now := newTestBreaker(1, time.Minute, 30*time.Second)
+	b.RecordResult(testServer, admit(t, b, testServer), true)
+	*now = now.Add(31 * time.Second)
+	probe := admit(t, b, testServer) // probe admitted, probePending=true
+	// The caller could not exercise the upstream (local gate rejected it): release the
+	// probe without a verdict. The breaker must NOT snap closed.
+	b.ReleaseProbe(testServer, probe)
+	// A subsequent request is admitted as the next probe (half-open), not as normal
+	// closed traffic — crucially the breaker did not reset to closed on release.
+	admit(t, b, testServer)
+	// While that probe is in flight, another is rejected — proof we are still half-open.
+	mustReject(t, b, testServer)
+}
+
+func TestBreakerIsolatesServers(t *testing.T) {
+	b, _ := newTestBreaker(1, time.Minute, 30*time.Second)
+	b.RecordResult(testServer, admit(t, b, testServer), true) // trip jp
+	mustReject(t, b, testServer)
+	// A different server is unaffected.
+	admit(t, b, harukiUtils.SupportedInheritUploadServer("en"))
+}
+
+// TestBreakerStragglerSuccessDoesNotReopen is the regression guard for the finding
+// that a straggler success re-closed an open breaker before its cooldown expired.
+func TestBreakerStragglerSuccessDoesNotReopen(t *testing.T) {
+	b, _ := newTestBreaker(3, time.Minute, 30*time.Second)
+	// A slow request is admitted while closed and keeps running.
+	straggler := admit(t, b, testServer)
+	// Three other failures trip the breaker.
+	for i := 0; i < 3; i++ {
+		b.RecordResult(testServer, admit(t, b, testServer), true)
+	}
+	mustReject(t, b, testServer) // open
+	// The straggler finally completes SUCCESSFULLY. It was admitted in the pre-trip
+	// epoch, so it must NOT re-close the open breaker and bypass the cooldown.
+	b.RecordResult(testServer, straggler, false)
+	mustReject(t, b, testServer) // still open
+}
+
+// TestBreakerStragglerDoesNotResolveHalfOpenProbe guards the symmetric case: a
+// straggler result arriving during half-open must not be mistaken for the probe.
+func TestBreakerStragglerDoesNotResolveHalfOpenProbe(t *testing.T) {
+	b, now := newTestBreaker(1, time.Minute, 30*time.Second)
+	straggler := admit(t, b, testServer)                      // admitted while closed
+	b.RecordResult(testServer, admit(t, b, testServer), true) // separate failure trips it
+	mustReject(t, b, testServer)
+	*now = now.Add(31 * time.Second)
+	probe := admit(t, b, testServer) // half-open probe
+	// The straggler completes with FAILURE during half-open; it must be ignored so the
+	// real probe permit stays in flight.
+	b.RecordResult(testServer, straggler, true)
+	mustReject(t, b, testServer) // still half-open, probe pending → rejected
+	// The real probe then succeeds → closes.
+	b.RecordResult(testServer, probe, false)
+	admit(t, b, testServer)
+}
+
+func TestConcurrencyLimiterBoundsPerServer(t *testing.T) {
+	l := newInheritConcurrencyLimiter(2)
+	if !l.acquire(testServer) {
+		t.Fatal("first acquire should succeed")
+	}
+	if !l.acquire(testServer) {
+		t.Fatal("second acquire should succeed")
+	}
+	if l.acquire(testServer) {
+		t.Fatal("third acquire should fail (capacity 2)")
+	}
+	// A different server has its own slots.
+	if !l.acquire(harukiUtils.SupportedInheritUploadServer("en")) {
+		t.Fatal("other server acquire should succeed")
+	}
+	// Releasing frees a slot.
+	l.release(testServer)
+	if !l.acquire(testServer) {
+		t.Fatal("acquire after release should succeed")
+	}
+}
+
+func TestConcurrencyLimiterReleaseWithoutHoldIsSafe(t *testing.T) {
+	l := newInheritConcurrencyLimiter(1)
+	// Releasing when nothing is held must not panic or over-fill.
+	l.release(testServer)
+	if !l.acquire(testServer) {
+		t.Fatal("acquire should succeed after spurious release")
+	}
+	if l.acquire(testServer) {
+		t.Fatal("capacity must remain 1 after spurious release")
+	}
+}

--- a/internal/modules/userprivateapi/game_bindings_handler.go
+++ b/internal/modules/userprivateapi/game_bindings_handler.go
@@ -1,6 +1,7 @@
 package userprivateapi
 
 import (
+	"context"
 	harukiApiHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/authorizesocialplatforminfo"
@@ -8,14 +9,20 @@ import (
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/socialplatforminfo"
 	harukiLogger "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/logger"
 	"sync"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"golang.org/x/sync/errgroup"
 )
 
+// gameBindingsReadTimeout bounds this token-gated read so it fails fast under
+// contention instead of hanging on the shared connection pools.
+const gameBindingsReadTimeout = 3 * time.Second
+
 func handleGetGameBindings(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		ctx := c.Context()
+		ctx, cancel := context.WithTimeout(c.Context(), gameBindingsReadTimeout)
+		defer cancel()
 		platform := c.Query("platform")
 		platformUserID := c.Query("platform_user_id")
 		if platform == "" || platformUserID == "" {

--- a/internal/modules/userprivateapi/private_data_handler.go
+++ b/internal/modules/userprivateapi/private_data_handler.go
@@ -1,6 +1,7 @@
 package userprivateapi
 
 import (
+	"context"
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	harukiApiHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql"
@@ -8,19 +9,61 @@ import (
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/gameaccountbinding"
 	harukiRedis "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/redis"
 	harukiLogger "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/logger"
+	perfdebug "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/perfdebug"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/gofiber/fiber/v3"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"golang.org/x/sync/singleflight"
 )
+
+// privateReadTimeout bounds the whole box-read path. Healthy reads are ~60ms, so
+// this ceiling only trips under real contention, where failing fast (5xx) is far
+// better than parking a DB connection until the client's ~30s timeout fires.
+const privateReadTimeout = 3 * time.Second
+
+// privateReadSlowThreshold is the total-read duration above which a per-stage
+// autopsy line is logged when profiling is enabled. It sits well above the healthy
+// ~60ms so it only fires on genuinely contended reads.
+const privateReadSlowThreshold = 500 * time.Millisecond
+
+// privateDataGroup collapses concurrent cache misses for the same cacheKey into a
+// single Mongo read + marshal + cache write, so a same-key burst does not stampede
+// the database with duplicate full-document pulls.
+var privateDataGroup singleflight.Group
 
 func handleGetPrivateData(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		ctx := c.Context()
+		// Bound every downstream DB/cache op so a contended read fails fast instead
+		// of parking a connection until the caller's ~30s timeout.
+		ctx, cancel := context.WithTimeout(c.Context(), privateReadTimeout)
+		defer cancel()
+		start := time.Now()
 		serverStr := c.Params("server")
 		dataTypeStr := c.Params("data_type")
 		userIDStr := c.Params("user_id")
+		// Slow-read autopsy: when profiling is on, log a per-stage breakdown for reads
+		// that cross the threshold, so a spike can be attributed to PG vs Redis vs
+		// Mongo without server-side slow logs (client-side pool waits are invisible
+		// there). Timestamps are captured unconditionally (~ns) and only formatted when
+		// the read is slow and profiling is enabled.
+		var dBinding, dAuth, dCache, dLoad time.Duration
+		defer func() {
+			if !perfdebug.Enabled() {
+				return
+			}
+			total := time.Since(start)
+			if total < privateReadSlowThreshold {
+				return
+			}
+			harukiLogger.Warnf("slow private read: server=%s data_type=%s user_id=%s total=%s binding=%s auth=%s cache=%s load=%s",
+				serverStr, dataTypeStr, userIDStr, total.Round(time.Millisecond),
+				dBinding.Round(time.Millisecond), dAuth.Round(time.Millisecond),
+				dCache.Round(time.Millisecond), dLoad.Round(time.Millisecond))
+		}()
 		platform := c.Query("platform")
 		platformUserID := c.Query("platform_user_id")
 		if platform == "" || platformUserID == "" {
@@ -41,6 +84,7 @@ func handleGetPrivateData(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers)
 		// Resolve the data owner from the verified binding first; the authorization
 		// check below must be scoped to that owner, so the two queries cannot run
 		// concurrently.
+		bindingStart := time.Now()
 		gameAccountBinding, bindingErr := apiHelper.DBManager.DB.GameAccountBinding.Query().
 			Where(
 				gameaccountbinding.ServerEQ(string(server)),
@@ -51,6 +95,7 @@ func handleGetPrivateData(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers)
 				query.WithSocialPlatformInfo()
 			}).
 			Only(ctx)
+		dBinding = time.Since(bindingStart)
 		if bindingErr != nil {
 			if lookupErr := mapPrivateGameAccountLookupError(bindingErr); lookupErr != nil {
 				if lookupErr.Code == fiber.StatusNotFound {
@@ -86,6 +131,7 @@ func handleGetPrivateData(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers)
 			dbUser.Edges.SocialPlatformInfo.Platform == platform &&
 			dbUser.Edges.SocialPlatformInfo.PlatformUserID == platformUserID
 		if !authorized {
+			authStart := time.Now()
 			exists, authErr := apiHelper.DBManager.DB.AuthorizeSocialPlatformInfo.Query().
 				Where(
 					authorizesocialplatforminfo.UserIDEQ(dbUser.ID),
@@ -93,6 +139,7 @@ func handleGetPrivateData(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers)
 					authorizesocialplatforminfo.PlatformUserIDEQ(platformUserID),
 				).
 				Exist(ctx)
+			dAuth = time.Since(authStart)
 			if authErr != nil {
 				harukiLogger.Errorf("Failed to verify private api authorization (platform=%s,platform_user_id=%s): %v", platform, platformUserID, authErr)
 				return harukiApiHelper.ErrorInternal(c, "failed to verify authorization")
@@ -104,28 +151,120 @@ func handleGetPrivateData(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers)
 		}
 		requestKey := c.Query("key")
 		cacheKey := harukiRedis.BuildGameDataCacheKey("private", string(server), string(dataType), userID, requestKey)
-		if cached, found, cErr := apiHelper.DBManager.Redis.GetRawCache(ctx, cacheKey); cErr == nil && found {
+		cacheStart := time.Now()
+		cached, cacheFound, cErr := apiHelper.DBManager.Redis.GetRawCache(ctx, cacheKey)
+		dCache = time.Since(cacheStart)
+		if cErr == nil && cacheFound {
 			c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
 			return c.SendString(cached)
 		} else if cErr != nil {
 			harukiLogger.Warnf("Failed to read private game data cache: %v", cErr)
 		}
-		result, err := apiHelper.DBManager.Mongo.GetData(ctx, userID, string(server), dataType)
+		loadStart := time.Now()
+		body, found, err := loadPrivateData(apiHelper, cacheKey, server, dataType, userID, requestKey)
+		dLoad = time.Since(loadStart)
 		if lookupErr := mapPrivateDataQueryError(err); lookupErr != nil {
 			harukiLogger.Errorf("Failed to query private user data (server=%s,user_id=%s,data_type=%s): %v", server, userIDStr, dataType, err)
 			return harukiApiHelper.ErrorInternal(c, lookupErr.Message)
 		}
-		if len(result) == 0 {
+		if !found {
 			return harukiApiHelper.ErrorNotFound(c, "game data not found")
 		}
-		resp := buildPrivateDataResponse(requestKey, result)
-		if encoded, mErr := sonic.Marshal(resp); mErr == nil {
-			if cErr := apiHelper.DBManager.Redis.SetRawCache(ctx, cacheKey, string(encoded), 300*time.Second); cErr != nil {
-				harukiLogger.Warnf("Failed to write private game data cache: %v", cErr)
-			}
-		} else {
-			harukiLogger.Warnf("Failed to marshal private game data cache: %v", mErr)
-		}
-		return c.JSON(resp)
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+		return c.SendString(body)
 	}
+}
+
+// loadPrivateData resolves the JSON body for cacheKey, collapsing concurrent
+// same-key misses via singleflight so a burst does a single Mongo pull + marshal +
+// cache write. It reports whether the document exists and marshals the response
+// exactly once (the previous code marshaled once for the cache and again in c.JSON).
+func loadPrivateData(
+	apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers,
+	cacheKey string,
+	server harukiUtils.SupportedDataUploadServer,
+	dataType harukiUtils.UploadDataType,
+	userID int64,
+	requestKey string,
+) (string, bool, error) {
+	type payload struct {
+		body  string
+		found bool
+	}
+	v, err, _ := privateDataGroup.Do(cacheKey, func() (any, error) {
+		// Detach from any single caller's request lifetime: this fetch serves every
+		// coalesced waiter, so a leader disconnecting must not fail the others. It is
+		// still bounded so it cannot run away.
+		fetchCtx, cancel := context.WithTimeout(context.Background(), privateReadTimeout)
+		defer cancel()
+		result, fetchErr := fetchPrivateData(fetchCtx, apiHelper, server, dataType, userID, requestKey)
+		if fetchErr != nil {
+			return nil, fetchErr
+		}
+		if len(result) == 0 {
+			return payload{found: false}, nil
+		}
+		encoded, encErr := sonic.Marshal(buildPrivateDataResponse(requestKey, result))
+		if encErr != nil {
+			return nil, encErr
+		}
+		// Detach the cache write from the request deadline so a near-deadline but
+		// successful read still populates the cache for subsequent requests.
+		cacheCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if cErr := apiHelper.DBManager.Redis.SetRawCache(cacheCtx, cacheKey, string(encoded), 300*time.Second); cErr != nil {
+			harukiLogger.Warnf("Failed to write private game data cache: %v", cErr)
+		}
+		return payload{body: string(encoded), found: true}, nil
+	})
+	if err != nil {
+		return "", false, err
+	}
+	p := v.(payload)
+	return p.body, p.found, nil
+}
+
+// fetchPrivateData reads the stored document, projecting to only the requested
+// keys when a comma-separated `key` filter is supplied so the box read no longer
+// transfers and decodes the full multi-MB document for a keyed request.
+func fetchPrivateData(
+	ctx context.Context,
+	apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers,
+	server harukiUtils.SupportedDataUploadServer,
+	dataType harukiUtils.UploadDataType,
+	userID int64,
+	requestKey string,
+) (bson.D, error) {
+	if projection := buildKeyProjection(requestKey); projection != nil {
+		return apiHelper.DBManager.Mongo.GetDataWithProjection(ctx, userID, string(server), dataType, projection)
+	}
+	return apiHelper.DBManager.Mongo.GetData(ctx, userID, string(server), dataType)
+}
+
+// buildKeyProjection returns an inclusion projection limited to the requested keys,
+// or nil when no explicit key was requested — in which case the caller fetches the
+// full document, matching legacy behavior.
+//
+// We intentionally do NOT exclude _id. Excluding it would make Mongo return an empty
+// document when a request asks only for keys the document does not contain, which the
+// len()==0 check would then misreport as "not found" (404) even though the account
+// exists. Keeping the implicit _id inclusion guarantees an existing document always
+// projects to a non-empty result; _id never appears in the response because
+// buildPrivateDataResponse only emits the explicitly requested keys.
+func buildKeyProjection(requestKey string) bson.M {
+	if requestKey == "" {
+		return nil
+	}
+	projection := bson.M{}
+	for _, k := range strings.Split(requestKey, ",") {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		projection[k] = 1
+	}
+	if len(projection) == 0 {
+		return nil
+	}
+	return projection
 }

--- a/internal/modules/userprivateapi/projection_test.go
+++ b/internal/modules/userprivateapi/projection_test.go
@@ -1,0 +1,51 @@
+package userprivateapi
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestBuildKeyProjection(t *testing.T) {
+	cases := []struct {
+		name       string
+		requestKey string
+		want       bson.M
+	}{
+		{"no key returns nil (full document)", "", nil},
+		{"single key", "userCards", bson.M{"userCards": 1}},
+		{"multiple keys", "userCards,userAreas", bson.M{"userCards": 1, "userAreas": 1}},
+		{"trims whitespace", " userCards , userAreas ", bson.M{"userCards": 1, "userAreas": 1}},
+		{"skips empty segments", "userCards,,userAreas", bson.M{"userCards": 1, "userAreas": 1}},
+		{"all-empty segments returns nil", " , , ", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildKeyProjection(tc.requestKey)
+			if len(got) != len(tc.want) {
+				t.Fatalf("buildKeyProjection(%q) = %v, want %v", tc.requestKey, got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Fatalf("buildKeyProjection(%q)[%q] = %v, want %v", tc.requestKey, k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildKeyProjectionNeverExcludesID is a regression guard: excluding _id makes
+// Mongo return an empty document when a request asks only for fields the document
+// does not contain, which the caller's len()==0 check would misreport as a 404 for a
+// live account. A projection must therefore never set _id to 0.
+func TestBuildKeyProjectionNeverExcludesID(t *testing.T) {
+	for _, requestKey := range []string{"userCards", "a,b,c", " userDecks ", "missingField"} {
+		projection := buildKeyProjection(requestKey)
+		if projection == nil {
+			t.Fatalf("buildKeyProjection(%q) unexpectedly returned nil", requestKey)
+		}
+		if v, ok := projection["_id"]; ok {
+			t.Fatalf("buildKeyProjection(%q) must not project _id (got _id=%v); excluding it breaks the exists/not-found signal", requestKey, v)
+		}
+	}
+}

--- a/utils/database/mongo/pool_stats.go
+++ b/utils/database/mongo/pool_stats.go
@@ -1,0 +1,128 @@
+package manager
+
+import (
+	"sync/atomic"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/event"
+)
+
+// PoolStats accumulates MongoDB connection-pool telemetry from the driver's
+// PoolMonitor event stream. Unlike database/sql the mongo driver exposes no Stats()
+// snapshot, so pool health — the client-side checkout wait that is invisible to the
+// server-side slow-query log — can only be observed by tallying pool events. The
+// driver may invoke the monitor callback concurrently, so every field is atomic.
+//
+// Gauge fields (checkedOut, pending) reflect current state. The remaining fields are
+// interval accumulators reset by Snapshot, so each sample reports what happened since
+// the previous sample rather than an ever-growing total.
+type PoolStats struct {
+	checkedOut atomic.Int64 // connections currently checked out (in use)
+	pending    atomic.Int64 // checkout requests started but not yet satisfied/failed
+
+	created          atomic.Int64 // connections opened, since last snapshot
+	closed           atomic.Int64 // connections closed, since last snapshot
+	checkouts        atomic.Int64 // successful checkouts, since last snapshot
+	checkoutFailures atomic.Int64 // failed checkouts, since last snapshot
+	waitSamples      atomic.Int64 // checkout attempts (success+failure) that waited, since last snapshot
+	waitNanosTotal   atomic.Int64 // summed checkout wait over waitSamples, since last snapshot
+	waitNanosMax     atomic.Int64 // max single checkout wait, since last snapshot
+}
+
+// NewPoolStats returns a zero-valued collector ready to be attached via Monitor.
+func NewPoolStats() *PoolStats {
+	return &PoolStats{}
+}
+
+// Monitor returns an *event.PoolMonitor that feeds this collector. Pass it to
+// WithPoolMonitor when constructing the manager.
+func (s *PoolStats) Monitor() *event.PoolMonitor {
+	return &event.PoolMonitor{Event: s.handle}
+}
+
+func (s *PoolStats) handle(evt *event.PoolEvent) {
+	if s == nil || evt == nil {
+		return
+	}
+	switch evt.Type {
+	case event.ConnectionCreated:
+		s.created.Add(1)
+	case event.ConnectionClosed:
+		s.closed.Add(1)
+	case event.ConnectionCheckOutStarted:
+		s.pending.Add(1)
+	case event.ConnectionCheckedOut:
+		s.pending.Add(-1)
+		s.checkedOut.Add(1)
+		s.checkouts.Add(1)
+		s.waitSamples.Add(1)
+		s.waitNanosTotal.Add(int64(evt.Duration))
+		storeMaxNanos(&s.waitNanosMax, int64(evt.Duration))
+	case event.ConnectionCheckOutFailed:
+		// A checkout that waited then failed (e.g. pool exhaustion / selection
+		// timeout) is the strongest saturation signal, so its wait counts toward the
+		// mean/max just like a successful one.
+		s.pending.Add(-1)
+		s.checkoutFailures.Add(1)
+		s.waitSamples.Add(1)
+		s.waitNanosTotal.Add(int64(evt.Duration))
+		storeMaxNanos(&s.waitNanosMax, int64(evt.Duration))
+	case event.ConnectionCheckedIn:
+		s.checkedOut.Add(-1)
+	}
+}
+
+// PoolSnapshot is a point-in-time read of a PoolStats. Gauge fields are current;
+// the rest cover the interval since the previous Snapshot call.
+type PoolSnapshot struct {
+	CheckedOut       int64
+	Pending          int64
+	Created          int64
+	Closed           int64
+	Checkouts        int64
+	CheckoutFailures int64
+	MeanWait         time.Duration
+	MaxWait          time.Duration
+}
+
+// Snapshot reads the current gauges and drains the interval accumulators back to
+// zero, so consecutive calls report per-interval deltas.
+//
+// This is a best-effort diagnostic, not an exact meter: the sample count and the
+// summed wait are two independent atomics drained by separate Swap calls, so a
+// checkout completing between them can have its wait counted in one interval and its
+// sample in the next, transiently skewing MeanWait in a low-traffic window. The error
+// self-corrects the following interval and is negligible over meaningful sample
+// counts, so we accept it rather than lock the hot checkout path.
+func (s *PoolStats) Snapshot() PoolSnapshot {
+	samples := s.waitSamples.Swap(0)
+	waitNanos := s.waitNanosTotal.Swap(0)
+	var mean time.Duration
+	if samples > 0 {
+		mean = time.Duration(waitNanos / samples)
+	}
+	return PoolSnapshot{
+		CheckedOut:       s.checkedOut.Load(),
+		Pending:          s.pending.Load(),
+		Created:          s.created.Swap(0),
+		Closed:           s.closed.Swap(0),
+		Checkouts:        s.checkouts.Swap(0),
+		CheckoutFailures: s.checkoutFailures.Swap(0),
+		MeanWait:         mean,
+		MaxWait:          time.Duration(s.waitNanosMax.Swap(0)),
+	}
+}
+
+// storeMaxNanos atomically raises a to v when v is larger, tolerating concurrent
+// writers via compare-and-swap.
+func storeMaxNanos(a *atomic.Int64, v int64) {
+	for {
+		old := a.Load()
+		if v <= old {
+			return
+		}
+		if a.CompareAndSwap(old, v) {
+			return
+		}
+	}
+}

--- a/utils/database/mongo/pool_stats_test.go
+++ b/utils/database/mongo/pool_stats_test.go
@@ -1,0 +1,75 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/event"
+)
+
+func TestPoolStatsSnapshot(t *testing.T) {
+	s := NewPoolStats()
+	m := s.Monitor()
+
+	emit := func(typ string, d time.Duration) {
+		m.Event(&event.PoolEvent{Type: typ, Duration: d})
+	}
+
+	// Two connections created, two checkouts (one slow), one still in use.
+	emit(event.ConnectionCreated, 0)
+	emit(event.ConnectionCreated, 0)
+	emit(event.ConnectionCheckOutStarted, 0)
+	emit(event.ConnectionCheckedOut, 2*time.Millisecond)
+	emit(event.ConnectionCheckOutStarted, 0)
+	emit(event.ConnectionCheckedOut, 8*time.Millisecond)
+	emit(event.ConnectionCheckedIn, 0) // one returned; one still checked out
+	emit(event.ConnectionCheckOutStarted, 0)
+	emit(event.ConnectionCheckOutFailed, 5*time.Millisecond) // pending resolved as failure
+	emit(event.ConnectionClosed, 0)
+
+	snap := s.Snapshot()
+	if snap.CheckedOut != 1 {
+		t.Errorf("CheckedOut = %d, want 1", snap.CheckedOut)
+	}
+	if snap.Pending != 0 {
+		t.Errorf("Pending = %d, want 0", snap.Pending)
+	}
+	if snap.Checkouts != 2 {
+		t.Errorf("Checkouts = %d, want 2", snap.Checkouts)
+	}
+	if snap.CheckoutFailures != 1 {
+		t.Errorf("CheckoutFailures = %d, want 1", snap.CheckoutFailures)
+	}
+	if snap.Created != 2 {
+		t.Errorf("Created = %d, want 2", snap.Created)
+	}
+	if snap.Closed != 1 {
+		t.Errorf("Closed = %d, want 1", snap.Closed)
+	}
+	if want := 5 * time.Millisecond; snap.MeanWait != want { // (2+8+5)/3, failure wait included
+		t.Errorf("MeanWait = %s, want %s", snap.MeanWait, want)
+	}
+	if want := 8 * time.Millisecond; snap.MaxWait != want {
+		t.Errorf("MaxWait = %s, want %s", snap.MaxWait, want)
+	}
+
+	// Interval accumulators reset; the gauge (CheckedOut) persists.
+	snap2 := s.Snapshot()
+	if snap2.Checkouts != 0 || snap2.CheckoutFailures != 0 || snap2.Created != 0 || snap2.Closed != 0 {
+		t.Errorf("interval counters not reset: %+v", snap2)
+	}
+	if snap2.MaxWait != 0 || snap2.MeanWait != 0 {
+		t.Errorf("wait accumulators not reset: mean=%s max=%s", snap2.MeanWait, snap2.MaxWait)
+	}
+	if snap2.CheckedOut != 1 {
+		t.Errorf("CheckedOut gauge should persist, got %d", snap2.CheckedOut)
+	}
+}
+
+func TestPoolStatsNilSafe(t *testing.T) {
+	var s *PoolStats
+	// handle must tolerate a nil receiver / nil event without panicking.
+	s.Monitor().Event(nil)
+	s2 := NewPoolStats()
+	s2.handle(nil)
+}

--- a/utils/database/mongo/types.go
+++ b/utils/database/mongo/types.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	harukiLogger "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/logger"
+	"time"
 
+	"go.mongodb.org/mongo-driver/v2/event"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
@@ -29,11 +31,51 @@ func (m *MongoDBManager) Disconnect(ctx context.Context) error {
 	return m.client.Disconnect(ctx)
 }
 
+// mongoOptions holds optional construction tunables applied by MongoOption funcs.
+type mongoOptions struct {
+	poolMonitor *event.PoolMonitor
+}
+
+// MongoOption customizes NewMongoDBManager. The variadic form keeps existing
+// call sites (e.g. the backfill CLI) source-compatible.
+type MongoOption func(*mongoOptions)
+
+// WithPoolMonitor attaches a driver PoolMonitor so connection-pool telemetry can be
+// sampled. Pass PoolStats.Monitor(). Nil monitors are ignored.
+func WithPoolMonitor(m *event.PoolMonitor) MongoOption {
+	return func(o *mongoOptions) {
+		o.poolMonitor = m
+	}
+}
+
 func NewMongoDBManager(
 	ctx context.Context,
 	dbURL, db, suite, mysekai string,
+	opts ...MongoOption,
 ) (*MongoDBManager, error) {
-	client, err := mongo.Connect(options.Client().ApplyURI(dbURL))
+	var applied mongoOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&applied)
+		}
+	}
+	// Pool sizing keeps warm connections so bursts of serving reads do not pay
+	// the 2-at-a-time handshake penalty, and raises the ceiling above the driver
+	// default of 100. ServerSelectionTimeout is lowered from the 30s default so a
+	// transient topology/primary issue fails fast instead of parking a request for
+	// 30s. NOTE: we intentionally do NOT set a client-level SetTimeout (CSOT) here —
+	// that would also bound cursor/backfill lifetime and break long scans. Per-op
+	// deadlines (context.WithTimeout in the serving handlers) bound the hot reads.
+	clientOpts := options.Client().
+		ApplyURI(dbURL).
+		SetMaxPoolSize(200).
+		SetMinPoolSize(20).
+		SetMaxConnecting(10).
+		SetServerSelectionTimeout(10 * time.Second)
+	if applied.poolMonitor != nil {
+		clientOpts.SetPoolMonitor(applied.poolMonitor)
+	}
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		harukiLogger.Errorf("Failed to connect to MongoDB: %v", err)
 		return nil, err

--- a/utils/handler/preprocess.go
+++ b/utils/handler/preprocess.go
@@ -128,10 +128,16 @@ func (h *DataHandler) validateOtherServerImagePath(
 	return h.verifyGameAccountExists(uid, server)
 }
 
+// gameAccountVerifyTimeout bounds the synchronous game-API existence check. It runs
+// deep in the upload-preprocess chain while the caller holds an uploadSemaphore slot,
+// so without an explicit deadline a degraded game API would pin that slot for the
+// full client timeout, throttling upload throughput during an outage.
+const gameAccountVerifyTimeout = 5 * time.Second
+
 func (h *DataHandler) verifyGameAccountExists(uid string, server utils.SupportedDataUploadServer) error {
-	// This runs deep in the synchronous upload-preprocess chain which carries no
-	// context; the Sekai API client's request timeout bounds the call.
-	resultInfo, _, err := h.SekaiAPIClient.GetUserProfile(context.Background(), uid, string(server))
+	ctx, cancel := context.WithTimeout(context.Background(), gameAccountVerifyTimeout)
+	defer cancel()
+	resultInfo, _, err := h.SekaiAPIClient.GetUserProfile(ctx, uid, string(server))
 	if resultInfo == nil {
 		if err != nil {
 			return err

--- a/utils/perfdebug/perfdebug.go
+++ b/utils/perfdebug/perfdebug.go
@@ -1,0 +1,20 @@
+// Package perfdebug exposes a single process-wide toggle for opt-in performance
+// instrumentation (pool/GC sampling, slow-request autopsies). It is off by default
+// and flipped once at bootstrap from backend.profiling_enabled, so hot paths can gate
+// diagnostic work behind a cheap atomic load without importing the config package.
+package perfdebug
+
+import "sync/atomic"
+
+var enabled atomic.Bool
+
+// SetEnabled sets the global profiling toggle. Called once during bootstrap.
+func SetEnabled(v bool) {
+	enabled.Store(v)
+}
+
+// Enabled reports whether opt-in profiling instrumentation should run. It is a single
+// atomic load, safe to call on hot paths.
+func Enabled() bool {
+	return enabled.Load()
+}

--- a/utils/sekai/client_bootstrap.go
+++ b/utils/sekai/client_bootstrap.go
@@ -74,9 +74,14 @@ func (c *HarukiSekaiClient) getCookies(ctx context.Context, retries int) error {
 	var lastErr error
 
 	for i := range retries {
+		if i > 0 {
+			clientSleep(time.Duration(i) * 500 * time.Millisecond)
+		}
 		status, headers, _, err := c.httpClient.RequestWithHeaders(ctx, httpMethodPost, url, nil, nil)
 		if err != nil {
-			lastErr = err
+			// Wrap as APIError{0} (transport failure) so a hard-down signature host is
+			// visible to the inherit circuit breaker's degradation classifier.
+			lastErr = NewAPIError(url, httpMethodPost, 0, "request failed", err)
 			c.logger.Warnf("Cookie request failed (attempt %d/%d): %v", i+1, retries, err)
 			continue
 		}
@@ -96,7 +101,7 @@ func (c *HarukiSekaiClient) getCookies(ctx context.Context, retries int) error {
 			c.logger.Errorf("Cookie response missing Set-Cookie header")
 			continue
 		}
-		lastErr = fmt.Errorf("unexpected status code: %d", status)
+		lastErr = NewAPIError(url, httpMethodPost, status, "unexpected status code", nil)
 		c.logger.Errorf("Cookie request failed with status %d", status)
 	}
 
@@ -115,9 +120,14 @@ func (c *HarukiSekaiClient) parseAppVersion(ctx context.Context, retries int) er
 	var lastErr error
 
 	for i := range retries {
+		if i > 0 {
+			clientSleep(time.Duration(i) * 500 * time.Millisecond)
+		}
 		status, _, body, err := c.httpClient.Request(ctx, httpMethodGet, c.versionURL, nil, nil)
 		if err != nil {
-			lastErr = err
+			// Wrap as APIError{0} (transport failure) so a hard-down version host is
+			// visible to the inherit circuit breaker's degradation classifier.
+			lastErr = NewAPIError(c.versionURL, httpMethodGet, 0, "request failed", err)
 			c.logger.Warnf("Version request failed (attempt %d/%d): %v", i+1, retries, err)
 			continue
 		}
@@ -132,7 +142,7 @@ func (c *HarukiSekaiClient) parseAppVersion(ctx context.Context, retries int) er
 			c.logger.Infof("Parsed %s server app version: %s", serverName, versionData.AppVersion)
 			return nil
 		}
-		lastErr = fmt.Errorf("unexpected status code: %d", status)
+		lastErr = NewAPIError(c.versionURL, httpMethodGet, status, "unexpected status code", nil)
 		c.logger.Errorf("Version request failed with status %d", status)
 	}
 
@@ -166,10 +176,10 @@ func (c *HarukiSekaiClient) generateInheritToken() (string, error) {
 }
 
 func (c *HarukiSekaiClient) Init(ctx context.Context) error {
-	if err := c.getCookies(ctx, 4); err != nil {
+	if err := c.getCookies(ctx, 2); err != nil {
 		return err
 	}
-	if err := c.parseAppVersion(ctx, 4); err != nil {
+	if err := c.parseAppVersion(ctx, 2); err != nil {
 		return err
 	}
 	if err := c.InheritAccount(ctx, true); err != nil {

--- a/utils/sekai/client_constants.go
+++ b/utils/sekai/client_constants.go
@@ -5,6 +5,15 @@ import "time"
 const (
 	defaultSekaiClientTimeout = 15 * time.Second
 
+	// retrieverRunTimeout caps one full inherit sequence (init + suite + home +
+	// mysekai — ~20 sequential per-call-timeout game-API calls with sleeps between
+	// them). The request ctx carries no deadline, so without this cap a degraded
+	// game API can hang the request goroutine for the unbounded sum of every
+	// per-call timeout (~300s worst case). It is set well above a healthy run
+	// (~30-50s) so slow-but-successful inherits are not aborted, while still
+	// bounding the pathological case.
+	retrieverRunTimeout = 90 * time.Second
+
 	httpMethodGet  = "GET"
 	httpMethodPost = "POST"
 	httpMethodPut  = "PUT"

--- a/utils/sekai/retriever_run.go
+++ b/utils/sekai/retriever_run.go
@@ -6,6 +6,12 @@ import (
 )
 
 func (r *HarukiSekaiDataRetriever) Run(ctx context.Context) (*harukiUtils.SekaiInheritDataRetrieverResponse, error) {
+	// Bound the entire inherit sequence so a degraded upstream cannot hang the
+	// caller for the unbounded sum of every per-call timeout. This does not make
+	// the handler asynchronous (a separate change) — it only caps how long one
+	// inherit can occupy the request goroutine.
+	ctx, cancel := context.WithTimeout(ctx, retrieverRunTimeout)
+	defer cancel()
 	if err := r.client.Init(ctx); err != nil {
 		r.isErrorExist = true
 		r.ErrorMessage = err.Error()


### PR DESCRIPTION
## Background

Investigation of ~30s HarukiBot **box** (private-data) reads. Root cause (code-verified): the box read ran every DB/cache op on `c.Context()` — which in Fiber v3 is `context.Background()` (no deadline, never cancelled on disconnect). Under contention the only ceiling was the Mongo driver's **default 30s server-selection timeout**, exactly the measured 30364/30122ms. It is a **client-side pool/selection wait, invisible to Mongo's server-side slow log** ("healthy Mongo, zero slow reads").

The on-host field report's theory — "failed background game-API pulls saturate serving concurrency so reads queue" — was **refuted**: Fiber sets no `Concurrency` cap, the retriever holds no DB connection during game-API hangs, and uploads are already bounded (`uploadSemaphore=10`). The game-API degradation and the slow reads co-occur via a common cause (a JP event spike), not cause→effect.

## Changes

### Serving-read hardening (the latency fix)
- **3s deadlines** on the two token-gated reads (`private_data_handler.go`, `game_bindings_handler.go`) — contended reads now fail fast instead of parking a connection ~30s.
- **Mongo** pool sizing + `SetServerSelectionTimeout(10s)`; deliberately **no** client `SetTimeout` (CSOT would bound cursor/backfill lifetime).
- **PostgreSQL** pool sizing via `openTunedSQLDB` for the toolbox + bot pools (was unlimited-open / 2-idle).
- Box read: **projected** reads for keyed requests (was pulling the full multi-MB doc), **single** marshal, and **singleflight** to collapse same-key miss stampedes.

### Inherit robustness — kept synchronous; client contract unchanged
- **Per-server circuit breaker**: trips on upstream degradation (timeouts / 5xx / 429 / maintenance / transport failure), **not** on 4xx user errors (bad credentials, incomplete tutorial, ban). Returns **503 + `Retry-After`** while open.
- **Per-server bounded concurrency limiter** (cap 8) → **429** when full, instead of piling up slow goroutines against one game server.
- **Generation tokens** so a straggler result from a pre-trip epoch cannot re-close an open breaker or disrupt a fresh half-open probe.
- `getCookies`/`parseAppVersion` (which bypass `callAPI`) now emit `APIError`, so Init-phase degradation is visible to the breaker's classifier.
- Retriever run cap (90s) + init retry backoff; mysekai preprocess bounded to 5s.

### Opt-in profiling — `backend.profiling_enabled` (default off)
- Mongo `PoolMonitor` checkout-wait / failure telemetry (the client-side wait the slow log can't see).
- Periodic sampler logging Mongo pool + PG `sql.DBStats` (both pools) + Go GC/goroutines.
- Per-stage box-read autopsy for reads over 500ms (attributes a slow read to PG vs Redis vs Mongo).

## Testing
`gofmt` · `go build ./...` · `go vet ./...` · `staticcheck` · `go test -race -count=1 ./...` → **58 packages pass, 0 data races**. New unit tests cover the breaker state machine (incl. two straggler regression guards), the degradation classifier, the concurrency limiter, the Mongo pool-stats collector, and the key-projection guard.

## Review
Adversarially reviewed with a multi-agent workflow (8 dimensions, each finding independently verified by 3 skeptics). It surfaced **4 real issues — all fixed in this PR** (transport-failure classification, the breaker straggler race → generation tokens, Init-phase degradation visibility, pool-stats mean skew documented) — and correctly dismissed 2.

## Notes
- **Security invariants preserved**: no change to box-read authorization/IDOR flow — the profiling additions are purely additive timing; the review verified the auth control flow is unchanged.
- The `cmd/suite-rec-backfill` import fix (stale `haruki-suite/*` → current module path) is applied in the working tree but **left gitignored** (`.gitignore:48`), respecting the existing deliberate exclusion of that local one-off CLI. Un-gitignoring it is a separate decision.
- To conclusively pin the saturating resource during the next spike, enable `profiling_enabled` and capture the pool/GC sample lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
