### PR TITLE
[Fix] Isolate Kratos HTTP client from shared default transport

### DIFF
--- a/utils/api/session_handler.go
+++ b/utils/api/session_handler.go
@@ -150,6 +150,23 @@ func (s *SessionHandler) hasKratosProviderConfigured() bool {
 	return strings.TrimSpace(s.KratosPublicURL) != ""
 }
 
+// kratosSharedTransport is a dedicated clone of http.DefaultTransport used as the
+// base for all Kratos HTTP calls. Cloning preserves DefaultTransport's proxy, TLS and
+// dial settings while giving the Kratos client its own connection pool, isolated from
+// the global default pool. That isolation matters under test: httptest.Server.Close()
+// calls http.DefaultTransport.CloseIdleConnections(), so when the Kratos client shared
+// DefaultTransport a sibling parallel test tearing down its server could yank a pooled
+// connection out from under an in-flight request ("http: CloseIdleConnections called").
+// A dedicated transport removes that shared state with no change to production behavior.
+var kratosSharedTransport = cloneDefaultTransport()
+
+func cloneDefaultTransport() http.RoundTripper {
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		return t.Clone()
+	}
+	return http.DefaultTransport
+}
+
 func (s *SessionHandler) kratosHTTPClient() *http.Client {
 	if s.KratosHTTPClient != nil {
 		return s.KratosHTTPClient
@@ -161,7 +178,7 @@ func (s *SessionHandler) kratosHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &kratosRequestMetadataTransport{
-			base: http.DefaultTransport,
+			base: kratosSharedTransport,
 		},
 	}
 }


### PR DESCRIPTION
## Problem

CI intermittently fails on `TestRevokeKratosSessionsByIdentityID` (`utils/api`) with:

```
net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
```

### Root cause
`kratosHTTPClient()` used **`http.DefaultTransport`** as its base, so the Kratos client shared the process-global connection pool. The Kratos flow tests use `t.Parallel()` with per-test `httptest.NewServer` + `defer server.Close()`, and **`httptest.Server.Close()` calls `http.DefaultTransport.CloseIdleConnections()`**. So a sibling parallel test tearing down its server could close a pooled connection out from under another test's in-flight Kratos request → the flake. It is not the dependency bumps and not a product bug; it only surfaces under the shared-transport + parallel-teardown pattern.

## Fix
Give the Kratos client a **dedicated transport** — a `Clone()` of `http.DefaultTransport` (which preserves its proxy / TLS / dial settings) — so its connection pool is isolated from the global default pool that `httptest` mutates.

This is also a small production hardening: a service's Kratos admin client no longer shares the global default pool. No behavioral change (all settings are cloned).

## Testing
`gofmt` · `go build ./...` · `go vet` · `staticcheck` clean. `go test -race` on `utils/api` passes, including heavy stress (`-count=25 -parallel 16`) of the parallel Kratos tests that exercise the teardown race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)