### PR TITLE
[Fix] Harden remaining serving reads, async mail, atomic chunk store

### DIFF
--- a/ent/toolbox/schema/gameaccountbinding.go
+++ b/ent/toolbox/schema/gameaccountbinding.go
@@ -32,6 +32,12 @@ func (GameAccountBinding) Edges() []ent.Edge {
 func (GameAccountBinding) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("server", "game_user_id").Unique(),
+		// Index the implicit user FK column: every per-owner binding lookup
+		// (browser /me and /settings eager loads, bot bindings resolution,
+		// OAuth2 userinfo, iOS per-chunk ownership checks) filters on it, and
+		// without an index each one sequential-scans a monotonically growing
+		// table.
+		index.Edges("user"),
 	}
 }
 

--- a/internal/modules/admintickets/ticket_handlers.go
+++ b/internal/modules/admintickets/ticket_handlers.go
@@ -1,7 +1,9 @@
 package admintickets
 
 import (
+	"context"
 	adminCoreModule "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/modules/admincore"
+	platformMailNotify "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/platform/mailnotify"
 	platformPagination "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/platform/pagination"
 	platformTicketNotifications "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/platform/ticketnotifications"
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
@@ -163,9 +165,14 @@ func handleAdminAppendTicketMessage(apiHelper *harukiAPIHelper.HarukiToolboxRout
 		}
 
 		if !payload.Internal {
+			// Notify off the request path: the send result was always discarded
+			// (log-only). BuildEvent clones every request-derived string, so the
+			// event is safe to read after this handler returns.
 			event := platformTicketNotifications.BuildEvent(row, actorUserID, message, apiHelper.SMTPClient)
 			event.Ticket.Status = ticket.StatusPendingUser
-			platformTicketNotifications.NotifyUserOfAdminReply(c.Context(), apiHelper.DBManager.DB, event)
+			platformMailNotify.Dispatch(func(ctx context.Context) {
+				platformTicketNotifications.NotifyUserOfAdminReply(ctx, apiHelper.DBManager.DB, event)
+			})
 		}
 		userNameByUserID, err := loadAdminTicketUserNames(c, apiHelper, collectAdminTicketMessageSenderUserIDs([]*postgresql.TicketMessage{savedMessage}))
 		if err != nil {

--- a/internal/modules/oauth2/gamedata.go
+++ b/internal/modules/oauth2/gamedata.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	userCoreModule "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/modules/usercore"
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
@@ -13,11 +14,25 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/gofiber/fiber/v3"
+	"golang.org/x/sync/singleflight"
 )
+
+// oauth2GameDataReadTimeout bounds the whole OAuth2 game-data read (PG access
+// check, Redis cache ops, Mongo fetch) — Fiber v3 request contexts carry no
+// deadline, so this mirrors the private box-read fix.
+const oauth2GameDataReadTimeout = 3 * time.Second
+
+// oauth2GameDataGroup collapses concurrent cache misses for the same cacheKey
+// into a single Mongo read + marshal + cache write (see publicDataGroup for why
+// misses on these surfaces are correlated).
+var oauth2GameDataGroup singleflight.Group
 
 func handleOAuth2GetGameData(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		ctx := c.Context()
+		// Bound every downstream DB/cache op so a contended read fails fast
+		// instead of parking a connection — mirrors the private box-read path.
+		ctx, cancel := context.WithTimeout(c.Context(), oauth2GameDataReadTimeout)
+		defer cancel()
 
 		serverStr := c.Params("server")
 		dataTypeStr := c.Params("data_type")
@@ -61,19 +76,7 @@ func handleOAuth2GetGameData(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpe
 			harukiLogger.Warnf("Failed to read OAuth2 game data cache: %v", cErr)
 		}
 
-		var resp any
-		publicAPIAllowedKeys := apiHelper.GetPublicAPIAllowedKeys()
-		allowedKeySet := make(map[string]struct{}, len(publicAPIAllowedKeys))
-		for _, k := range publicAPIAllowedKeys {
-			allowedKeySet[k] = struct{}{}
-		}
-
-		if dataType == harukiUtils.UploadDataTypeSuite {
-			resp, err = data.HandleSuiteRequest(c, apiHelper, gameUserID, server, requestKey, allowedKeySet, publicAPIAllowedKeys)
-		} else {
-			resp, err = data.HandleMysekaiRequest(c, apiHelper, gameUserID, server, requestKey)
-		}
-
+		body, err := loadOAuth2GameData(apiHelper, cacheKey, server, dataType, gameUserID, requestKey)
 		if err != nil {
 			if fErr, ok := err.(*fiber.Error); ok {
 				return harukiAPIHelper.UpdatedDataResponse[string](c, fErr.Code, fErr.Message, nil)
@@ -81,16 +84,64 @@ func handleOAuth2GetGameData(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpe
 			harukiLogger.Errorf("Failed to load OAuth2 game data: %v", err)
 			return harukiAPIHelper.ErrorInternal(c, "failed to get user data")
 		}
-
-		if encoded, mErr := sonic.Marshal(resp); mErr == nil {
-			if cErr := apiHelper.DBManager.Redis.SetRawCache(ctx, cacheKey, string(encoded), 300*time.Second); cErr != nil {
-				harukiLogger.Warnf("Failed to write OAuth2 game data cache: %v", cErr)
-			}
-		} else {
-			harukiLogger.Warnf("Failed to marshal OAuth2 game data cache: %v", mErr)
-		}
-		return c.JSON(resp)
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+		return c.SendString(body)
 	}
+}
+
+// loadOAuth2GameData resolves the JSON body for cacheKey, collapsing concurrent
+// same-key misses via singleflight and marshaling the response exactly once —
+// the same shape as loadPublicGameData/loadPrivateData. The access check stays
+// with the per-request caller; only the post-authz materialization is shared.
+func loadOAuth2GameData(
+	apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers,
+	cacheKey string,
+	server harukiUtils.SupportedDataUploadServer,
+	dataType harukiUtils.UploadDataType,
+	gameUserID int64,
+	requestKey string,
+) (string, error) {
+	// Key the flight on cacheKey plus the raw request key (see loadPublicGameData):
+	// only byte-identical requests may share a result; the cache itself stays
+	// keyed by the trimmed cacheKey.
+	flightKey := cacheKey + "\x00" + requestKey
+	v, err, _ := oauth2GameDataGroup.Do(flightKey, func() (any, error) {
+		// Detached from any single caller's request lifetime; still bounded.
+		fetchCtx, cancel := context.WithTimeout(context.Background(), oauth2GameDataReadTimeout)
+		defer cancel()
+		publicAPIAllowedKeys := apiHelper.GetPublicAPIAllowedKeys()
+		allowedKeySet := make(map[string]struct{}, len(publicAPIAllowedKeys))
+		for _, k := range publicAPIAllowedKeys {
+			allowedKeySet[k] = struct{}{}
+		}
+		var resp any
+		var loadErr error
+		if dataType == harukiUtils.UploadDataTypeSuite {
+			resp, loadErr = data.HandleSuiteRequest(fetchCtx, apiHelper, gameUserID, server, requestKey, allowedKeySet, publicAPIAllowedKeys)
+		} else {
+			resp, loadErr = data.HandleMysekaiRequest(fetchCtx, apiHelper, gameUserID, server, requestKey)
+		}
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		encoded, mErr := sonic.Marshal(resp)
+		if mErr != nil {
+			return nil, mErr
+		}
+		body := string(encoded)
+		// Detach the cache write from the read deadline so a near-deadline but
+		// successful read still populates the cache for subsequent requests.
+		cacheCtx, cancelCache := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancelCache()
+		if cErr := apiHelper.DBManager.Redis.SetRawCache(cacheCtx, cacheKey, body, 300*time.Second); cErr != nil {
+			harukiLogger.Warnf("Failed to write OAuth2 game data cache: %v", cErr)
+		}
+		return body, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
 }
 
 func registerOAuth2GameDataRoutes(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers) {

--- a/internal/modules/public/public.go
+++ b/internal/modules/public/public.go
@@ -15,7 +15,20 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/gofiber/fiber/v3"
+	"golang.org/x/sync/singleflight"
 )
+
+// publicReadTimeout bounds the whole public read path (PG binding lookup, Redis
+// cache ops, Mongo fetch). Fiber v3 request contexts carry no deadline, so
+// without this a stalled dependency parks the request indefinitely — the same
+// landmine class fixed for private box reads in v8.3.0.
+const publicReadTimeout = 3 * time.Second
+
+// publicDataGroup collapses concurrent cache misses for the same cacheKey into a
+// single Mongo read + marshal + cache write. Misses here are correlated: every
+// upload invalidates all cached surfaces for that user and then fans out webhook
+// notifications, so subscribers commonly re-fetch the same key at once.
+var publicDataGroup singleflight.Group
 
 func validatePublicAPIAccess(record *postgresql.GameAccountBinding, dataType harukiUtils.UploadDataType) bool {
 	if record == nil || !record.Verified {
@@ -35,7 +48,10 @@ func validatePublicAPIAccess(record *postgresql.GameAccountBinding, dataType har
 
 func handlePublicDataRequest(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		ctx := c.Context()
+		// Bound every downstream DB/cache op so a contended read fails fast
+		// instead of parking a connection — mirrors the private box-read path.
+		ctx, cancel := context.WithTimeout(c.Context(), publicReadTimeout)
+		defer cancel()
 		server, dataType, userID, userIDStr, parseErr := parseParams(c)
 		if parseErr != nil {
 			return harukiAPIHelper.ErrorNotFound(c, "not found")
@@ -55,7 +71,6 @@ func handlePublicDataRequest(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpe
 			return harukiAPIHelper.ErrorNotFound(c, "not found")
 		}
 
-		var resp any
 		requestKey := c.Query("key")
 		cacheKey := harukiRedis.BuildGameDataCacheKey("public", string(server), string(dataType), userID, requestKey)
 		if cached, found, err := apiHelper.DBManager.Redis.GetRawCache(ctx, cacheKey); err == nil && found {
@@ -64,16 +79,7 @@ func handlePublicDataRequest(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpe
 		} else if err != nil {
 			harukiLogger.Warnf("Failed to read public game data cache: %v", err)
 		}
-		publicAPIAllowedKeys := apiHelper.GetPublicAPIAllowedKeys()
-		allowedKeySet := make(map[string]struct{}, len(publicAPIAllowedKeys))
-		for _, k := range publicAPIAllowedKeys {
-			allowedKeySet[k] = struct{}{}
-		}
-		if dataType == harukiUtils.UploadDataTypeSuite {
-			resp, err = data.HandleSuiteRequest(c, apiHelper, userID, server, requestKey, allowedKeySet, publicAPIAllowedKeys)
-		} else {
-			resp, err = data.HandleMysekaiRequest(c, apiHelper, userID, server, requestKey)
-		}
+		body, err := loadPublicGameData(apiHelper, cacheKey, server, dataType, userID, requestKey)
 		if err != nil {
 			if fErr, ok := err.(*fiber.Error); ok {
 				if fErr.Code == fiber.StatusInternalServerError {
@@ -84,15 +90,68 @@ func handlePublicDataRequest(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpe
 			harukiLogger.Errorf("Failed to load public game data: %v", err)
 			return harukiAPIHelper.ErrorInternal(c, "failed to get user data")
 		}
-		if encoded, mErr := sonic.Marshal(resp); mErr == nil {
-			if err := apiHelper.DBManager.Redis.SetRawCache(ctx, cacheKey, string(encoded), 300*time.Second); err != nil {
-				harukiLogger.Warnf("Failed to write public game data cache: %v", err)
-			}
-		} else {
-			harukiLogger.Warnf("Failed to marshal public game data cache: %v", mErr)
-		}
-		return c.JSON(resp)
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+		return c.SendString(body)
 	}
+}
+
+// loadPublicGameData resolves the JSON body for cacheKey, collapsing concurrent
+// same-key misses via singleflight and marshaling the response exactly once (the
+// previous code encoded once for the cache and again in c.JSON) — the same shape
+// as loadPrivateData on the private box-read path. Authorization stays with the
+// per-request caller; only the post-authz data materialization is shared.
+func loadPublicGameData(
+	apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers,
+	cacheKey string,
+	server harukiUtils.SupportedDataUploadServer,
+	dataType harukiUtils.UploadDataType,
+	userID int64,
+	requestKey string,
+) (string, error) {
+	// Key the flight on cacheKey plus the raw request key: BuildGameDataCacheKey
+	// trims whitespace, so two raw keys can map to one cacheKey while producing
+	// different responses (a padded key fails validation). Only byte-identical
+	// requests may share a result; the cache itself stays keyed by cacheKey.
+	flightKey := cacheKey + "\x00" + requestKey
+	v, err, _ := publicDataGroup.Do(flightKey, func() (any, error) {
+		// Detached from any single caller's request lifetime: this fetch serves
+		// every coalesced waiter, so a leader disconnecting must not fail the
+		// others. Still bounded so it cannot run away.
+		fetchCtx, cancel := context.WithTimeout(context.Background(), publicReadTimeout)
+		defer cancel()
+		publicAPIAllowedKeys := apiHelper.GetPublicAPIAllowedKeys()
+		allowedKeySet := make(map[string]struct{}, len(publicAPIAllowedKeys))
+		for _, k := range publicAPIAllowedKeys {
+			allowedKeySet[k] = struct{}{}
+		}
+		var resp any
+		var loadErr error
+		if dataType == harukiUtils.UploadDataTypeSuite {
+			resp, loadErr = data.HandleSuiteRequest(fetchCtx, apiHelper, userID, server, requestKey, allowedKeySet, publicAPIAllowedKeys)
+		} else {
+			resp, loadErr = data.HandleMysekaiRequest(fetchCtx, apiHelper, userID, server, requestKey)
+		}
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		encoded, mErr := sonic.Marshal(resp)
+		if mErr != nil {
+			return nil, mErr
+		}
+		body := string(encoded)
+		// Detach the cache write from the read deadline so a near-deadline but
+		// successful read still populates the cache for subsequent requests.
+		cacheCtx, cancelCache := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancelCache()
+		if cErr := apiHelper.DBManager.Redis.SetRawCache(cacheCtx, cacheKey, body, 300*time.Second); cErr != nil {
+			harukiLogger.Warnf("Failed to write public game data cache: %v", cErr)
+		}
+		return body, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
 }
 
 func parseParams(c fiber.Ctx) (harukiUtils.SupportedDataUploadServer, harukiUtils.UploadDataType, int64, string, *fiber.Error) {

--- a/internal/modules/upload/ios_chunk_store.go
+++ b/internal/modules/upload/ios_chunk_store.go
@@ -6,15 +6,12 @@ import (
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	harukiRedis "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/redis"
 	"strconv"
-	"sync"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
 )
 
 const iosChunkUploadTTL = 5 * time.Minute
-
-var iosUploadChunkStoreMu sync.Mutex
 
 const (
 	iosUploadChunkStateIncomplete int64 = iota
@@ -29,6 +26,45 @@ type iosUploadChunkPersistResult struct {
 	Count int
 	Size  int64
 }
+
+// persistIOSUploadChunkScript runs the whole check-then-write persist as one
+// atomic server-side operation, replacing a process-global mutex held across
+// 5-6 sequential Redis round trips. Atomicity in Redis (instead of a Go lock)
+// means: (a) concurrent uploaders no longer serialize behind one slow command
+// for ALL users, (b) the size accounting stays correct across multiple backend
+// replicas, and (c) the old chunk body is never transferred just to learn its
+// length (HSTRLEN is O(1)).
+//
+// KEYS[1]=meta hash  KEYS[2]=chunk-data hash  KEYS[3]=claim key
+// ARGV[1]=totalChunks ARGV[2]=chunkIndex ARGV[3]=chunkData ARGV[4]=maxSize ARGV[5]=ttlMs
+// Reply: {state, count, size} matching iosUploadChunkPersistResult; a stored
+// meta field that fails tonumber() is treated as inconsistent/absent rather
+// than erroring — only this script ever writes those fields.
+var persistIOSUploadChunkScript = goredis.NewScript(`
+local total = redis.call('HGET', KEYS[1], 'total')
+if total and total ~= '' and tonumber(total) ~= tonumber(ARGV[1]) then
+  return {-1, 0, 0}
+end
+local size = tonumber(redis.call('HGET', KEYS[1], 'size') or 0) or 0
+local oldLen = redis.call('HSTRLEN', KEYS[2], ARGV[2])
+local newSize = size - oldLen + string.len(ARGV[3])
+if newSize > tonumber(ARGV[4]) then
+  return {-2, redis.call('HLEN', KEYS[2]), size}
+end
+redis.call('HSET', KEYS[1], 'total', ARGV[1], 'size', tostring(newSize))
+redis.call('HSET', KEYS[2], ARGV[2], ARGV[3])
+redis.call('PEXPIRE', KEYS[1], ARGV[5])
+redis.call('PEXPIRE', KEYS[2], ARGV[5])
+local count = redis.call('HLEN', KEYS[2])
+if count ~= tonumber(ARGV[1]) then
+  redis.call('DEL', KEYS[3])
+  return {0, count, newSize}
+end
+if redis.call('SET', KEYS[3], '1', 'NX', 'PX', ARGV[5]) then
+  return {1, count, newSize}
+end
+return {2, count, newSize}
+`)
 
 func iosUploadRedisKeys(uploadKey string) (metaKey string, chunkDataKey string, claimKey string) {
 	return harukiRedis.BuildIOSUploadChunkMetaKey(uploadKey),
@@ -49,98 +85,24 @@ func persistIOSUploadChunk(
 	}
 
 	metaKey, chunkDataKey, claimKey := iosUploadRedisKeys(uploadKey)
-	chunkIndexField := strconv.Itoa(chunkIndex)
-
-	iosUploadChunkStoreMu.Lock()
-	defer iosUploadChunkStoreMu.Unlock()
-
-	meta, err := redisClient.HGetAll(ctx, metaKey).Result()
+	vals, err := persistIOSUploadChunkScript.Run(ctx, redisClient,
+		[]string{metaKey, chunkDataKey, claimKey},
+		totalChunks,
+		strconv.Itoa(chunkIndex),
+		chunkData,
+		maxDataChunksSize,
+		iosChunkUploadTTL.Milliseconds(),
+	).Int64Slice()
 	if err != nil {
 		return iosUploadChunkPersistResult{}, err
 	}
-
-	currentSize := int64(0)
-	if rawTotal, ok := meta["total"]; ok && rawTotal != "" {
-		expectedTotal, parseErr := strconv.Atoi(rawTotal)
-		if parseErr != nil {
-			return iosUploadChunkPersistResult{}, fmt.Errorf("parse stored total chunks: %w", parseErr)
-		}
-		if expectedTotal != totalChunks {
-			return iosUploadChunkPersistResult{State: iosUploadChunkStateInconsistentTotal}, nil
-		}
-	}
-	if rawSize, ok := meta["size"]; ok && rawSize != "" {
-		parsedSize, parseErr := strconv.ParseInt(rawSize, 10, 64)
-		if parseErr != nil {
-			return iosUploadChunkPersistResult{}, fmt.Errorf("parse stored upload size: %w", parseErr)
-		}
-		currentSize = parsedSize
-	}
-
-	oldChunkData, err := redisClient.HGet(ctx, chunkDataKey, chunkIndexField).Bytes()
-	if err != nil && err != goredis.Nil {
-		return iosUploadChunkPersistResult{}, err
-	}
-	if err == goredis.Nil {
-		oldChunkData = nil
-	}
-
-	newSize := currentSize - int64(len(oldChunkData)) + int64(len(chunkData))
-	if newSize > maxDataChunksSize {
-		count, countErr := redisClient.HLen(ctx, chunkDataKey).Result()
-		if countErr != nil {
-			return iosUploadChunkPersistResult{}, countErr
-		}
-		return iosUploadChunkPersistResult{
-			State: iosUploadChunkStateTooLarge,
-			Count: int(count),
-			Size:  currentSize,
-		}, nil
-	}
-
-	pipe := redisClient.TxPipeline()
-	pipe.HSet(ctx, metaKey, map[string]any{
-		"total": totalChunks,
-		"size":  newSize,
-	})
-	pipe.HSet(ctx, chunkDataKey, chunkIndexField, chunkData)
-	pipe.Expire(ctx, metaKey, iosChunkUploadTTL)
-	pipe.Expire(ctx, chunkDataKey, iosChunkUploadTTL)
-	if _, err := pipe.Exec(ctx); err != nil {
-		return iosUploadChunkPersistResult{}, err
-	}
-
-	count, err := redisClient.HLen(ctx, chunkDataKey).Result()
-	if err != nil {
-		return iosUploadChunkPersistResult{}, err
-	}
-	if int(count) != totalChunks {
-		if err := redisClient.Del(ctx, claimKey).Err(); err != nil {
-			return iosUploadChunkPersistResult{}, err
-		}
-		return iosUploadChunkPersistResult{
-			State: iosUploadChunkStateIncomplete,
-			Count: int(count),
-			Size:  newSize,
-		}, nil
-	}
-
-	setStatus, err := redisClient.SetArgs(ctx, claimKey, "1", goredis.SetArgs{
-		Mode: "NX",
-		TTL:  iosChunkUploadTTL,
-	}).Result()
-	if err != nil && err != goredis.Nil {
-		return iosUploadChunkPersistResult{}, err
-	}
-	claimed := err == nil && setStatus == "OK"
-	state := iosUploadChunkStateCompleteAlreadyClaimed
-	if claimed {
-		state = iosUploadChunkStateCompleteClaimed
+	if len(vals) != 3 {
+		return iosUploadChunkPersistResult{}, fmt.Errorf("unexpected persist script reply length %d", len(vals))
 	}
 	return iosUploadChunkPersistResult{
-		State: state,
-		Count: int(count),
-		Size:  newSize,
+		State: vals[0],
+		Count: int(vals[1]),
+		Size:  vals[2],
 	}, nil
 }
 
@@ -156,9 +118,8 @@ func loadIOSUploadChunks(
 
 	_, chunkDataKey, _ := iosUploadRedisKeys(uploadKey)
 
-	iosUploadChunkStoreMu.Lock()
-	defer iosUploadChunkStoreMu.Unlock()
-
+	// No lock needed: the claim SETNX in the persist script elects a single
+	// assembler, and HGETALL is atomic so it observes a consistent chunk set.
 	rawChunks, err := redisClient.HGetAll(ctx, chunkDataKey).Result()
 	if err != nil {
 		return nil, err

--- a/internal/modules/upload/ios_test.go
+++ b/internal/modules/upload/ios_test.go
@@ -3,11 +3,65 @@ package upload
 import (
 	"context"
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
 	goredis "github.com/redis/go-redis/v9"
 )
+
+// TestIOSUploadChunkStoreConcurrentPersistAccounting guards the atomicity of the
+// persist script: size accounting must stay exact under concurrent writers with
+// no process-level lock (the pre-Lua implementation needed a global mutex for
+// this, which also serialized unrelated users). Each goroutine persists a
+// distinct chunk of a shared upload; afterwards the stored size must equal the
+// exact sum of chunk lengths and the chunk count must equal the writer count.
+func TestIOSUploadChunkStoreConcurrentPersistAccounting(t *testing.T) {
+	t.Parallel()
+
+	client := newIOSUploadRedisClient(t)
+	ctx := context.Background()
+	uploadKey := buildChunkUploadKey("toolbox-user", harukiUtils.SupportedDataUploadServerJP, 424242, "upload-id")
+
+	const totalChunks = 16
+	chunk := []byte("0123456789abcdef")
+	var wg sync.WaitGroup
+	errs := make([]error, totalChunks)
+	for i := 0; i < totalChunks; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, errs[idx] = persistIOSUploadChunk(ctx, client, uploadKey, totalChunks, idx, chunk)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("persistIOSUploadChunk(%d) returned error: %v", i, err)
+		}
+	}
+
+	metaKey, chunkDataKey, _ := iosUploadRedisKeys(uploadKey)
+	rawSize, err := client.HGet(ctx, metaKey, "size").Result()
+	if err != nil {
+		t.Fatalf("HGet(size) returned error: %v", err)
+	}
+	size, err := strconv.ParseInt(rawSize, 10, 64)
+	if err != nil {
+		t.Fatalf("parse stored size %q: %v", rawSize, err)
+	}
+	if want := int64(totalChunks * len(chunk)); size != want {
+		t.Fatalf("stored size = %d, want %d", size, want)
+	}
+	count, err := client.HLen(ctx, chunkDataKey).Result()
+	if err != nil {
+		t.Fatalf("HLen returned error: %v", err)
+	}
+	if count != totalChunks {
+		t.Fatalf("chunk count = %d, want %d", count, totalChunks)
+	}
+}
 
 func TestValidateDataUploadHeader(t *testing.T) {
 	t.Parallel()

--- a/internal/modules/usergamebindings/game_account_data.go
+++ b/internal/modules/usergamebindings/game_account_data.go
@@ -1,6 +1,7 @@
 package usergamebindings
 
 import (
+	"context"
 	userCoreModule "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/modules/usercore"
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
@@ -12,6 +13,10 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 )
+
+// ownedGameAccountReadTimeout bounds the owned-account data read (PG access
+// check + Mongo fetch); Fiber v3 request contexts carry no deadline.
+const ownedGameAccountReadTimeout = 3 * time.Second
 
 type ownedGameAccountDataType string
 
@@ -42,7 +47,11 @@ func buildPublicAPIAllowedKeySet(apiHelper *harukiAPIHelper.HarukiToolboxRouterH
 
 func handleGetOwnedGameAccountData(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		ctx := c.Context()
+		// Bound the PG access check and Mongo reads; the profile branch keeps the
+		// request context because it proxies an upstream game-API call with its
+		// own client-side timeout.
+		ctx, cancel := context.WithTimeout(c.Context(), ownedGameAccountReadTimeout)
+		defer cancel()
 
 		authUserID, err := userCoreModule.CurrentUserID(c)
 		if err != nil {
@@ -80,13 +89,13 @@ func handleGetOwnedGameAccountData(apiHelper *harukiAPIHelper.HarukiToolboxRoute
 
 		switch dataType {
 		case ownedGameAccountDataTypeSuite:
-			resp, err := handleOwnedSuiteData(c, apiHelper, gameUserID, server)
+			resp, err := handleOwnedSuiteData(ctx, c, apiHelper, gameUserID, server)
 			if err != nil {
 				return respondVerifiedGameAccountDataError(c, err)
 			}
 			return c.JSON(resp)
 		case ownedGameAccountDataTypeMysekai:
-			resp, err := data.HandleMysekaiRequest(c, apiHelper, gameUserID, server, c.Query("key"))
+			resp, err := data.HandleMysekaiRequest(ctx, apiHelper, gameUserID, server, c.Query("key"))
 			if err != nil {
 				return respondVerifiedGameAccountDataError(c, err)
 			}
@@ -102,9 +111,9 @@ func handleGetOwnedGameAccountData(apiHelper *harukiAPIHelper.HarukiToolboxRoute
 	}
 }
 
-func handleOwnedSuiteData(c fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, gameUserID int64, server harukiUtils.SupportedDataUploadServer) (any, error) {
+func handleOwnedSuiteData(ctx context.Context, c fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, gameUserID int64, server harukiUtils.SupportedDataUploadServer) (any, error) {
 	allowedKeySet, allowedKeys := buildPublicAPIAllowedKeySet(apiHelper)
-	return data.HandleSuiteRequest(c, apiHelper, gameUserID, server, c.Query("key"), allowedKeySet, allowedKeys)
+	return data.HandleSuiteRequest(ctx, apiHelper, gameUserID, server, c.Query("key"), allowedKeySet, allowedKeys)
 }
 
 func sendOwnedGameAccountProfile(c fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, gameUserIDStr string, server harukiUtils.SupportedDataUploadServer) error {

--- a/internal/modules/usergamebindings/gameaccount_handlers.go
+++ b/internal/modules/usergamebindings/gameaccount_handlers.go
@@ -1,10 +1,12 @@
 package usergamebindings
 
 import (
+	"context"
 	"errors"
 
 	userCoreModule "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/modules/usercore"
 	userEmailModule "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/modules/useremail"
+	platformMailNotify "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/platform/mailnotify"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql"
@@ -175,7 +177,16 @@ func handleCreateGameAccountBinding(apiHelper *harukiAPIHelper.HarukiToolboxRout
 		clearGameAccountPublicCaches(ctx, apiHelper, serverStr, gameUserIDStr)
 		if saveResult != nil && saveResult.Transferred {
 			previousOwnerUserID = saveResult.PreviousOwnerUserID
-			notifyPreviousGameAccountBindingOwner(apiHelper, saveResult, serverStr, gameUserIDStr, time.Now())
+			// Send the transfer mail off the request path: its result was always
+			// discarded (log-only), so a slow SMTP server should not delay the
+			// binding response. Clone the params — fiber recycles their backing
+			// buffers after the handler returns.
+			transferServer := strings.Clone(serverStr)
+			transferGameUserID := strings.Clone(gameUserIDStr)
+			transferredAt := time.Now()
+			platformMailNotify.Dispatch(func(context.Context) {
+				notifyPreviousGameAccountBindingOwner(apiHelper, saveResult, transferServer, transferGameUserID, transferredAt)
+			})
 		}
 
 		bindings, err := getUserBindings(ctx, apiHelper, userID)

--- a/internal/modules/usergamebindings/recommend_data.go
+++ b/internal/modules/usergamebindings/recommend_data.go
@@ -1,6 +1,7 @@
 package usergamebindings
 
 import (
+	"context"
 	"errors"
 	userCoreModule "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/modules/usercore"
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
@@ -10,9 +11,15 @@ import (
 	harukiLogger "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/logger"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 )
+
+// deckRecommendReadTimeout bounds the deck-recommend data read. It is wider than
+// the other read deadlines because mysekai mode issues two sequential Mongo
+// fetches (suite subset + mysekai subset).
+const deckRecommendReadTimeout = 5 * time.Second
 
 type deckRecommendDataMode string
 
@@ -59,7 +66,10 @@ func validateVerifiedOwnedGameAccountBinding(binding *postgresql.GameAccountBind
 
 func handleGetDeckRecommendData(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		ctx := c.Context()
+		// Bound the PG binding lookup and both Mongo fetches; Fiber v3 request
+		// contexts carry no deadline.
+		ctx, cancel := context.WithTimeout(c.Context(), deckRecommendReadTimeout)
+		defer cancel()
 		userID, err := userCoreModule.CurrentUserID(c)
 		if err != nil {
 			return harukiAPIHelper.ErrorUnauthorized(c, "user not authenticated")

--- a/internal/modules/usertickets/ticket_handlers.go
+++ b/internal/modules/usertickets/ticket_handlers.go
@@ -1,7 +1,9 @@
 package usertickets
 
 import (
+	"context"
 	userCoreModule "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/modules/usercore"
+	platformMailNotify "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/platform/mailnotify"
 	platformPagination "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/platform/pagination"
 	platformTicketNotifications "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/platform/ticketnotifications"
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
@@ -117,7 +119,14 @@ func handleCreateOwnTicket(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers
 		createdTicketID = ticketID
 		result = harukiAPIHelper.SystemLogResultSuccess
 		reason = "ok"
-		platformTicketNotifications.NotifyAdminsOfNewTicket(c.Context(), apiHelper.DBManager.DB, platformTicketNotifications.BuildEvent(createdTicket, userID, message, apiHelper.SMTPClient))
+		// Notify off the request path: the send result was always discarded
+		// (log-only), so the response should not wait on the SMTP conversation.
+		// BuildEvent clones every request-derived string, so the event is safe
+		// to read after this handler returns.
+		event := platformTicketNotifications.BuildEvent(createdTicket, userID, message, apiHelper.SMTPClient)
+		platformMailNotify.Dispatch(func(ctx context.Context) {
+			platformTicketNotifications.NotifyAdminsOfNewTicket(ctx, apiHelper.DBManager.DB, event)
+		})
 		resp := createUserTicketResponse{TicketID: ticketID}
 		return harukiAPIHelper.SuccessResponse(c, "ticket created", &resp)
 	}
@@ -294,7 +303,9 @@ func handleAppendOwnTicketMessage(apiHelper *harukiAPIHelper.HarukiToolboxRouter
 
 		event := platformTicketNotifications.BuildEvent(row, userID, message, apiHelper.SMTPClient)
 		event.Ticket.Status = ticket.StatusPendingAdmin
-		platformTicketNotifications.NotifyAdminsOfUserReply(c.Context(), apiHelper.DBManager.DB, event)
+		platformMailNotify.Dispatch(func(ctx context.Context) {
+			platformTicketNotifications.NotifyAdminsOfUserReply(ctx, apiHelper.DBManager.DB, event)
+		})
 		items := buildUserTicketMessageItems([]*postgresql.TicketMessage{createdMessage})
 		return harukiAPIHelper.SuccessResponse(c, "message added", &items[0])
 	}

--- a/internal/platform/mailnotify/dispatch.go
+++ b/internal/platform/mailnotify/dispatch.go
@@ -1,0 +1,47 @@
+// Package mailnotify dispatches best-effort notification mail off the request
+// path. Every caller already discarded the send result (log-only), so the HTTP
+// response never depended on SMTP completing — blocking the handler on a
+// 10-30s worst-case SMTP conversation bought nothing. Dispatch keeps the same
+// delivery semantics while removing that latency from the user-visible request.
+package mailnotify
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// maxConcurrentSends bounds background notification goroutines so an SMTP
+	// outage under sustained traffic cannot grow goroutines without bound.
+	maxConcurrentSends = 16
+	// jobTimeout bounds the whole notification job (recipient DB query plus the
+	// SMTP conversation, which additionally enforces its own dial/conversation
+	// deadlines internally).
+	jobTimeout = 30 * time.Second
+)
+
+var sendSlots = make(chan struct{}, maxConcurrentSends)
+
+// Dispatch runs job on a background goroutine when a worker slot is free and
+// falls back to running it synchronously when all slots are busy — saturation
+// degrades to the pre-async behavior instead of dropping notifications or
+// spawning unbounded goroutines. The job receives a background-derived context:
+// callers must not capture the fiber request context (or any request-buffer
+// backed strings) because fiber recycles them after the handler returns.
+func Dispatch(job func(ctx context.Context)) {
+	select {
+	case sendSlots <- struct{}{}:
+		go func() {
+			defer func() { <-sendSlots }()
+			run(job)
+		}()
+	default:
+		run(job)
+	}
+}
+
+func run(job func(ctx context.Context)) {
+	ctx, cancel := context.WithTimeout(context.Background(), jobTimeout)
+	defer cancel()
+	job(ctx)
+}

--- a/internal/platform/ticketnotifications/notifications.go
+++ b/internal/platform/ticketnotifications/notifications.go
@@ -148,20 +148,28 @@ func sendTicketMail(event Event, recipients []string, action string) {
 	}
 }
 
+// BuildEvent clones every request-derived string it stores: events outlive the
+// request handler (they are dispatched to a background mail worker), while
+// actorUserID and message may alias the pooled request body/header buffers
+// (sonic decodes with CopyString=false) and ent Create returns rows that still
+// hold the very input strings. Cloning here keeps the Event fully heap-owned no
+// matter which call site built it.
 func BuildEvent(ticketRow *postgresql.Ticket, actorUserID string, message string, mailSender MailSender) Event {
+	actor := strings.Clone(strings.TrimSpace(actorUserID))
+	message = strings.Clone(message)
 	if ticketRow == nil {
-		return Event{ActorUserID: strings.TrimSpace(actorUserID), Message: message, MailSender: mailSender, FrontendURL: config.Cfg.UserSystem.FrontendURL, DetailPath: "/tickets", DisplayName: config.Cfg.UserSystem.SMTP.MailName}
+		return Event{ActorUserID: actor, Message: message, MailSender: mailSender, FrontendURL: config.Cfg.UserSystem.FrontendURL, DetailPath: "/tickets", DisplayName: config.Cfg.UserSystem.SMTP.MailName}
 	}
 	return Event{
 		Ticket: TicketContext{
 			InternalID:      ticketRow.ID,
-			PublicID:        ticketRow.TicketID,
-			CreatorUserID:   ticketRow.CreatorUserID,
-			Subject:         ticketRow.Subject,
+			PublicID:        strings.Clone(ticketRow.TicketID),
+			CreatorUserID:   strings.Clone(ticketRow.CreatorUserID),
+			Subject:         strings.Clone(ticketRow.Subject),
 			Status:          ticketRow.Status,
-			AssigneeAdminID: ticketAssigneeAdminID(ticketRow),
+			AssigneeAdminID: strings.Clone(ticketAssigneeAdminID(ticketRow)),
 		},
-		ActorUserID: strings.TrimSpace(actorUserID),
+		ActorUserID: actor,
 		Message:     message,
 		FrontendURL: config.Cfg.UserSystem.FrontendURL,
 		DetailPath:  "/tickets",

--- a/utils/api/data/fetch.go
+++ b/utils/api/data/fetch.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"fmt"
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
@@ -61,9 +62,10 @@ func buildSuiteResponse(result bson.D, keys []string) bson.D {
 	return resp
 }
 
-func HandleSuiteRequest(c fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, userID int64, server harukiUtils.SupportedDataUploadServer, requestKey string, allowedKeySet map[string]struct{}, allowedKeys []string) (any, error) {
-	ctx := c.Context()
-
+// HandleSuiteRequest takes an explicit ctx (rather than deriving one from the
+// fiber request) so callers can bound the Mongo read with a deadline — Fiber v3
+// request contexts carry none.
+func HandleSuiteRequest(ctx context.Context, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, userID int64, server harukiUtils.SupportedDataUploadServer, requestKey string, allowedKeySet map[string]struct{}, allowedKeys []string) (any, error) {
 	var keys []string
 	if requestKey == "" {
 		keys = allowedKeys
@@ -105,9 +107,9 @@ func HandleSuiteRequest(c fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRou
 	return NormalizeProviderResponse(buildSuiteResponse(result, keys)), nil
 }
 
-func HandleMysekaiRequest(c fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, userID int64, server harukiUtils.SupportedDataUploadServer, requestKey string) (any, error) {
-	ctx := c.Context()
-
+// HandleMysekaiRequest takes an explicit ctx for the same reason as
+// HandleSuiteRequest: the caller owns the read deadline.
+func HandleMysekaiRequest(ctx context.Context, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, userID int64, server harukiUtils.SupportedDataUploadServer, requestKey string) (any, error) {
 	var keys []string
 	if requestKey != "" {
 		keys = strings.Split(requestKey, ",")

--- a/utils/database/postgresql/migrate/schema.go
+++ b/utils/database/postgresql/migrate/schema.go
@@ -85,6 +85,11 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{GameAccountBindingsColumns[1], GameAccountBindingsColumns[2]},
 			},
+			{
+				Name:    "gameaccountbinding_user_game_account_bindings",
+				Unique:  false,
+				Columns: []*schema.Column{GameAccountBindingsColumns[6]},
+			},
 		},
 	}
 	// GameAccountDataGrantsColumns holds the columns for the "game_account_data_grants" table.


### PR DESCRIPTION
## Summary

Follow-up to #54: a 99-agent adversarial performance audit of v8.3.0 confirmed six findings (out of 47 raw candidates); this PR implements all of them.

### Read-path hardening (same class as the v8.3.0 box-read fix, remaining surfaces)
- **3s deadlines** on public, OAuth2 game-data and owned-account reads, **5s** on deck-recommend (two sequential Mongo fetches). Fiber v3 request contexts carry no deadline, so these paths had no ceiling on a stalled established connection or PG pool wait — and they share the Mongo/PG pools with the already-fixed private box reads.
- **Marshal-once** on public/OAuth2 cache misses (previously encoded the multi-MB response twice: once for Redis, again in `c.JSON`).
- **Singleflight** on public/OAuth2 cache misses. Misses are correlated: every upload wipes all cached surfaces for that user then fans out webhook notifications, so subscribers re-fetch the same key at once. Flight key includes the raw request key (only byte-identical requests coalesce); authorization stays per-request.

### `game_account_bindings` owner FK index
Every per-owner binding lookup (browser `/me`, `/settings`, bot bindings resolution, OAuth2 userinfo, iOS per-chunk checks) filtered on the unindexed implicit FK column — 11k-row seq scan today, linear degradation with growth. Added `index.Edges("user")` + regenerated migration (applies via `auto_migrate`).

### Notification mail off the request path
Ticket create/reply and binding-transfer handlers blocked responses on a synchronous SMTP conversation (10-30s worst case) whose result was always discarded. New `internal/platform/mailnotify` bounded dispatcher (16 slots, 30s timeout, synchronous fallback on saturation). `BuildEvent` now clones every request-derived string — sonic decodes with `CopyString=false`, so body strings alias the pooled fasthttp buffer and must not escape into background goroutines. Verification-code mail stays synchronous (its result determines the response).

### Atomic iOS chunk persistence
The chunk store held a process-global mutex across 5-6 sequential Redis round trips, serializing all users' uploads behind one lock (a single slow Redis command stalled everyone, and the lock was single-process anyway). The persist is now one atomic Lua script (with `HSTRLEN` instead of transferring the old chunk body to learn its length), correct across replicas; the load path drops the lock (claim SETNX already elects one assembler). New concurrent-accounting regression test.

## Verification
- `gofmt` / `go build` / `go vet` / `staticcheck` clean; full `go test -race -count=1 ./...` passes
- Chunk-store Lua path covered by the 5 existing miniredis tests + new concurrency test
- Diff reviewed by a 21-agent adversarial workflow (5 dimensions × 2-skeptic verification); both confirmed findings (body-buffer strings escaping into async mail, singleflight key/fetch mismatch) fixed in place

## Explicitly unchanged
- Endpoint response semantics (status codes, bodies, cache keys/TTLs)
- Inherit stays synchronous; private-path behavior untouched
- No new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)