### PR TITLE
[Feat] Add conditional game-data reads via known_upload_time

### DIFF
--- a/docs/oauth2-client-integration.zh-CN.md
+++ b/docs/oauth2-client-integration.zh-CN.md
@@ -420,6 +420,16 @@ curl -X POST 'https://toolbox-api-direct.haruki.seiunx.com/api/oauth2/revoke' \
 - 同时返回 `userGamedata.userIdString` 作为字符串镜像，JS / TS 客户端应优先读取该字段以避免 64 位整数精度丢失
 - 当响应暴露顶层 `_id` 时，会同时返回 `_idString`
 
+条件拉取（避免重复拉取未变化的数据）：
+
+- 请求可附带 `?known_upload_time=<unix 秒>`，值取自上一次完整响应数据中的 `upload_time` 字段；如果你使用 `key` 过滤字段，必须把 `upload_time` 一并列入，否则该参数会被忽略（完整响应里也拿不到新的时间戳）
+- 若数据自那以后没有更新，直接返回 `304 Not Modified`（空响应体，附带 `X-Upload-Time` 响应头），客户端应继续使用本地已有数据；原本的"先探测 `upload_time` 再拉全量"两次请求可以合并为一次
+- 若数据已更新（或服务端无法确认未变化），返回完整数据，行为与不带该参数时完全一致；此时应从响应数据的 `upload_time` 字段刷新本地记录的值——完整响应不附带 `X-Upload-Time` 头，时间戳一律以响应体为准
+- 参数值非法时按未携带处理（类比 HTTP 对不可解析 `If-Modified-Since` 的处理方式），不会报错
+- 该参数不改变鉴权与字段可见性：suite 数据面上，若服务端配置的公开字段允许列表不含 `upload_time`，该参数会被忽略；`key` 过滤无效时不会返回 304，而是照常返回原有错误
+- 时间戳精度为 unix 秒，同一秒内的多次上传无法通过时间戳区分（该限制与"先探测 `upload_time` 再拉全量"的方式一致）；对一致性极敏感的场景请直接拉取完整数据
+- public API 与 private token API 的同形数据读取接口同样支持该参数
+
 ---
 
 ## 8. 当前可申请的 scope

--- a/docs/webhook-integration.zh-CN.md
+++ b/docs/webhook-integration.zh-CN.md
@@ -183,6 +183,7 @@ https://example.com/apiwebhook/jp/suite/123456789
 3. 服务端回调时，以回调是否收到为准，不要依赖同步确认
 4. 如果管理员更新了 `credential`，及时替换成新的 token
 5. 如果需要轮换授权，联系管理员更新 endpoint 并下发新 token
+6. 回调 body 为空，需要自行回源拉取数据；如果除回调外还有轮询兜底逻辑，轮询回源时建议附带 `?known_upload_time=<上次拉取到的 upload_time>`——数据未变化时服务端直接返回 `304 Not Modified`（空响应体，并附带 `X-Upload-Time` 响应头），避免重复拉取全量数据
 
 ## 11. 常见问题
 

--- a/internal/modules/oauth2/gamedata.go
+++ b/internal/modules/oauth2/gamedata.go
@@ -68,6 +68,9 @@ func handleOAuth2GetGameData(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpe
 		}
 
 		requestKey := c.Query("key")
+		if data.CheckNotModified(ctx, c, apiHelper, gameUserID, server, dataType, requestKey, true) {
+			return c.SendStatus(fiber.StatusNotModified)
+		}
 		cacheKey := harukiRedis.BuildGameDataCacheKey("oauth2", string(server), string(dataType), gameUserID, requestKey)
 		if cached, found, cErr := apiHelper.DBManager.Redis.GetRawCache(ctx, cacheKey); cErr == nil && found {
 			c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)

--- a/internal/modules/public/public.go
+++ b/internal/modules/public/public.go
@@ -72,6 +72,9 @@ func handlePublicDataRequest(apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpe
 		}
 
 		requestKey := c.Query("key")
+		if data.CheckNotModified(ctx, c, apiHelper, userID, server, dataType, requestKey, true) {
+			return c.SendStatus(fiber.StatusNotModified)
+		}
 		cacheKey := harukiRedis.BuildGameDataCacheKey("public", string(server), string(dataType), userID, requestKey)
 		if cached, found, err := apiHelper.DBManager.Redis.GetRawCache(ctx, cacheKey); err == nil && found {
 			c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)

--- a/internal/modules/userprivateapi/private_data_handler.go
+++ b/internal/modules/userprivateapi/private_data_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	harukiApiHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
+	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api/data"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/authorizesocialplatforminfo"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/gameaccountbinding"
@@ -150,6 +151,9 @@ func handleGetPrivateData(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers)
 			return harukiApiHelper.ErrorForbidden(c, "forbidden: invalid platform or platform_user_id for this user")
 		}
 		requestKey := c.Query("key")
+		if data.CheckNotModified(ctx, c, apiHelper, userID, server, dataType, requestKey, false) {
+			return c.SendStatus(fiber.StatusNotModified)
+		}
 		cacheKey := harukiRedis.BuildGameDataCacheKey("private", string(server), string(dataType), userID, requestKey)
 		cacheStart := time.Now()
 		cached, cacheFound, cErr := apiHelper.DBManager.Redis.GetRawCache(ctx, cacheKey)

--- a/utils/api/data/conditional.go
+++ b/utils/api/data/conditional.go
@@ -1,0 +1,144 @@
+package data
+
+import (
+	"context"
+	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
+	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
+	harukiLogger "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/logger"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+const (
+	// QueryKnownUploadTime is the query parameter carrying the upload_time the
+	// client already holds for this document. When it matches the stored stamp
+	// the endpoint answers 304 with no body, merging the previous probe+fetch
+	// two-round-trip pattern into one request.
+	QueryKnownUploadTime = "known_upload_time"
+	// HeaderUploadTime echoes the matched stamp on 304 responses. It is set
+	// ONLY there: a full response's stamp must be read from the body's own
+	// upload_time field, which cannot disagree with the body it arrived in —
+	// a header sourced from a fresh Mongo read can (the Redis body cache may
+	// briefly trail an upload), and a client adopting such a stamp would 304
+	// against a stale body until the next upload.
+	HeaderUploadTime = "X-Upload-Time"
+)
+
+// CheckNotModified implements the ?known_upload_time conditional read shared by
+// the public, private, and OAuth2 game-data endpoints. It must run only after
+// the caller has fully authorized the request. It reports true when the client
+// already holds the current document, in which case the caller responds 304.
+//
+// publicKeyFiltered is true on the public and OAuth2 surfaces, whose responses
+// are filtered through the public-API key allowlist; the private surface passes
+// false. The conditional read is disabled whenever answering 304 could diverge
+// from what the full path would say about the same request: a non-empty key
+// filter must include upload_time (otherwise the client cannot maintain its
+// stamp, and on allowlisted surfaces an existing document can project to an
+// empty result, which the full path 404s), on filtered surfaces the operator
+// must not have excluded upload_time from the allowlist (the 304/200
+// distinction is an equality oracle on a stamp the body itself would not
+// reveal) and the key filter must be one the full path accepts, and on the
+// private surface Mongo-operator/dotted/empty key segments are skipped so the
+// full path keeps owning their outcome.
+//
+// The check is a pure optimization and never introduces a new failure mode:
+// malformed values are ignored the way HTTP ignores an unparsable
+// If-Modified-Since, and a missing document or a lookup error falls through to
+// the existing full path, which owns the 404/500 semantics of its surface.
+func CheckNotModified(
+	ctx context.Context,
+	c fiber.Ctx,
+	apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers,
+	userID int64,
+	server harukiUtils.SupportedDataUploadServer,
+	dataType harukiUtils.UploadDataType,
+	requestKey string,
+	publicKeyFiltered bool,
+) bool {
+	known := ParseKnownUploadTime(c.Query(QueryKnownUploadTime))
+	if known <= 0 {
+		return false
+	}
+	if apiHelper == nil || apiHelper.DBManager == nil || apiHelper.DBManager.Mongo == nil {
+		return false
+	}
+	if requestKey != "" && !requestKeyIncludesUploadTime(requestKey) {
+		// A key filter without upload_time cannot maintain the client's stamp
+		// (full responses carry it only in the body), and on allowlisted
+		// surfaces it can project an existing document to an empty result,
+		// which the full path answers with 404 — never 304 those requests.
+		return false
+	}
+	if publicKeyFiltered {
+		if dataType == harukiUtils.UploadDataTypeSuite {
+			publicAPIAllowedKeys := apiHelper.GetPublicAPIAllowedKeys()
+			allowedKeySet := make(map[string]struct{}, len(publicAPIAllowedKeys))
+			for _, k := range publicAPIAllowedKeys {
+				allowedKeySet[k] = struct{}{}
+			}
+			if _, ok := allowedKeySet["upload_time"]; !ok {
+				return false
+			}
+			if _, invalid := InvalidSuiteRequestKey(requestKey, allowedKeySet); invalid {
+				return false
+			}
+		} else if _, invalid := InvalidMysekaiRequestKey(requestKey); invalid {
+			return false
+		}
+	} else if _, invalid := InvalidMysekaiRequestKey(requestKey); invalid {
+		// The private surface has no key allowlist, but a dotted, empty, or
+		// $-prefixed key segment changes the full path's outcome (nested
+		// projection or a Mongo projection error); skip the conditional answer
+		// and let the full path behave exactly as it always has.
+		return false
+	}
+	current, found, err := apiHelper.DBManager.Mongo.GetUploadTime(ctx, userID, string(server), dataType)
+	if err != nil {
+		harukiLogger.Warnf("Failed to read upload_time for conditional request (server=%s,data_type=%s,user_id=%d): %v", server, dataType, userID, err)
+		return false
+	}
+	if !notModifiedDecision(known, current, time.Now().Unix(), found) {
+		return false
+	}
+	c.Set(HeaderUploadTime, strconv.FormatInt(current, 10))
+	return true
+}
+
+// notModifiedDecision holds the pure 304 decision: the document must exist with
+// a positive stamp equal to the client's, and the stamp's second must have
+// fully elapsed — upload_time has 1-second resolution, so another upload landing
+// in the stamp's own second would overwrite the document without changing the
+// stamp, and a 304 issued inside that second could hide it.
+func notModifiedDecision(known, current, now int64, found bool) bool {
+	return found && current > 0 && current == known && current < now
+}
+
+// requestKeyIncludesUploadTime reports whether a non-empty key filter requests
+// the upload_time field itself. Keys are matched exactly, mirroring how the
+// full path splits them.
+func requestKeyIncludesUploadTime(requestKey string) bool {
+	for _, key := range strings.Split(requestKey, ",") {
+		if key == "upload_time" {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseKnownUploadTime parses a raw known_upload_time query value, returning 0
+// when it is absent or not a positive integer.
+func ParseKnownUploadTime(raw string) int64 {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	known, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || known <= 0 {
+		return 0
+	}
+	return known
+}

--- a/utils/api/data/conditional_test.go
+++ b/utils/api/data/conditional_test.go
@@ -1,0 +1,120 @@
+package data
+
+import "testing"
+
+func TestNotModifiedDecision(t *testing.T) {
+	const now = int64(1752600100)
+	cases := []struct {
+		name    string
+		known   int64
+		current int64
+		found   bool
+		want    bool
+	}{
+		{name: "match with elapsed second", known: 1752600000, current: 1752600000, found: true, want: true},
+		{name: "match but stamp second still open", known: now, current: now, found: true, want: false},
+		{name: "match but stamp in the future", known: now + 5, current: now + 5, found: true, want: false},
+		{name: "client stamp older", known: 1752590000, current: 1752600000, found: true, want: false},
+		{name: "client stamp newer", known: 1752600001, current: 1752600000, found: true, want: false},
+		{name: "document missing", known: 1752600000, current: 0, found: false, want: false},
+		{name: "document without stamp", known: 1752600000, current: 0, found: true, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := notModifiedDecision(tc.known, tc.current, now, tc.found); got != tc.want {
+				t.Fatalf("notModifiedDecision(%d, %d, %d, %v) = %v, want %v", tc.known, tc.current, now, tc.found, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequestKeyIncludesUploadTime(t *testing.T) {
+	cases := []struct {
+		name       string
+		requestKey string
+		want       bool
+	}{
+		{name: "single upload_time", requestKey: "upload_time", want: true},
+		{name: "among other keys", requestKey: "userCards,upload_time", want: true},
+		{name: "missing", requestKey: "userCards,userGamedata", want: false},
+		{name: "padded segment does not match", requestKey: "userCards, upload_time", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := requestKeyIncludesUploadTime(tc.requestKey); got != tc.want {
+				t.Fatalf("requestKeyIncludesUploadTime(%q) = %v, want %v", tc.requestKey, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInvalidSuiteRequestKey(t *testing.T) {
+	allowed := map[string]struct{}{"upload_time": {}, "userCards": {}}
+	cases := []struct {
+		name        string
+		requestKey  string
+		wantKey     string
+		wantInvalid bool
+	}{
+		{name: "empty filter", requestKey: ""},
+		{name: "allowed keys", requestKey: "upload_time,userCards"},
+		{name: "userGamedata is exempt", requestKey: "userGamedata,upload_time"},
+		{name: "disallowed key", requestKey: "userCards,secret", wantKey: "secret", wantInvalid: true},
+		{name: "empty segment", requestKey: "userCards,,upload_time", wantKey: "", wantInvalid: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, invalid := InvalidSuiteRequestKey(tc.requestKey, allowed)
+			if key != tc.wantKey || invalid != tc.wantInvalid {
+				t.Fatalf("InvalidSuiteRequestKey(%q) = (%q, %v), want (%q, %v)", tc.requestKey, key, invalid, tc.wantKey, tc.wantInvalid)
+			}
+		})
+	}
+}
+
+func TestInvalidMysekaiRequestKey(t *testing.T) {
+	cases := []struct {
+		name        string
+		requestKey  string
+		wantKey     string
+		wantInvalid bool
+	}{
+		{name: "empty filter", requestKey: ""},
+		{name: "plain keys", requestKey: "updatedResources,upload_time"},
+		{name: "dotted key", requestKey: "updatedResources.userMysekaiPhotos", wantKey: "updatedResources.userMysekaiPhotos", wantInvalid: true},
+		{name: "operator key", requestKey: "$where", wantKey: "$where", wantInvalid: true},
+		{name: "blank segment", requestKey: "updatedResources, ,upload_time", wantKey: " ", wantInvalid: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, invalid := InvalidMysekaiRequestKey(tc.requestKey)
+			if key != tc.wantKey || invalid != tc.wantInvalid {
+				t.Fatalf("InvalidMysekaiRequestKey(%q) = (%q, %v), want (%q, %v)", tc.requestKey, key, invalid, tc.wantKey, tc.wantInvalid)
+			}
+		})
+	}
+}
+
+func TestParseKnownUploadTime(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want int64
+	}{
+		{name: "absent", raw: "", want: 0},
+		{name: "valid", raw: "1752600000", want: 1752600000},
+		{name: "surrounding whitespace", raw: " 1752600000 ", want: 1752600000},
+		{name: "zero is ignored", raw: "0", want: 0},
+		{name: "negative is ignored", raw: "-5", want: 0},
+		{name: "non-numeric is ignored", raw: "latest", want: 0},
+		{name: "float is ignored", raw: "1752600000.5", want: 0},
+		{name: "overflow is ignored", raw: "99999999999999999999", want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ParseKnownUploadTime(tc.raw); got != tc.want {
+				t.Fatalf("ParseKnownUploadTime(%q) = %d, want %d", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/utils/api/data/fetch.go
+++ b/utils/api/data/fetch.go
@@ -62,6 +62,39 @@ func buildSuiteResponse(result bson.D, keys []string) bson.D {
 	return resp
 }
 
+// InvalidSuiteRequestKey returns the first requested suite key the allowlist
+// rejects. The conditional (?known_upload_time) path uses it as a gate so a
+// request the full path would 400 is never answered with a 304.
+func InvalidSuiteRequestKey(requestKey string, allowedKeySet map[string]struct{}) (string, bool) {
+	if requestKey == "" {
+		return "", false
+	}
+	for _, key := range strings.Split(requestKey, ",") {
+		if key == "userGamedata" {
+			continue
+		}
+		if _, ok := allowedKeySet[key]; !ok {
+			return key, true
+		}
+	}
+	return "", false
+}
+
+// InvalidMysekaiRequestKey returns the first requested mysekai key that is
+// empty or that Mongo would treat as a dotted projection path or operator, so
+// a caller cannot probe nested document structure.
+func InvalidMysekaiRequestKey(requestKey string) (string, bool) {
+	if requestKey == "" {
+		return "", false
+	}
+	for _, key := range strings.Split(requestKey, ",") {
+		if strings.TrimSpace(key) == "" || strings.ContainsAny(key, ".$") {
+			return key, true
+		}
+	}
+	return "", false
+}
+
 // HandleSuiteRequest takes an explicit ctx (rather than deriving one from the
 // fiber request) so callers can bound the Mongo read with a deadline — Fiber v3
 // request contexts carry none.
@@ -70,15 +103,10 @@ func HandleSuiteRequest(ctx context.Context, apiHelper *harukiAPIHelper.HarukiTo
 	if requestKey == "" {
 		keys = allowedKeys
 	} else {
-		keys = strings.Split(requestKey, ",")
-		for _, key := range keys {
-			if key == "userGamedata" {
-				continue
-			}
-			if _, ok := allowedKeySet[key]; !ok {
-				return nil, fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid request key: %s", key))
-			}
+		if key, invalid := InvalidSuiteRequestKey(requestKey, allowedKeySet); invalid {
+			return nil, fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid request key: %s", key))
 		}
+		keys = strings.Split(requestKey, ",")
 	}
 
 	projection := buildSuiteProjection(keys)
@@ -112,14 +140,10 @@ func HandleSuiteRequest(ctx context.Context, apiHelper *harukiAPIHelper.HarukiTo
 func HandleMysekaiRequest(ctx context.Context, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, userID int64, server harukiUtils.SupportedDataUploadServer, requestKey string) (any, error) {
 	var keys []string
 	if requestKey != "" {
-		keys = strings.Split(requestKey, ",")
-		for _, key := range keys {
-			// Reject keys Mongo would treat as a dotted projection path or operator,
-			// so a caller cannot probe nested document structure.
-			if strings.TrimSpace(key) == "" || strings.ContainsAny(key, ".$") {
-				return nil, fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid request key: %s", key))
-			}
+		if key, invalid := InvalidMysekaiRequestKey(requestKey); invalid {
+			return nil, fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid request key: %s", key))
 		}
+		keys = strings.Split(requestKey, ",")
 	}
 
 	projection := buildMysekaiProjection(keys)

--- a/utils/database/mongo/data_ops.go
+++ b/utils/database/mongo/data_ops.go
@@ -346,6 +346,37 @@ func (m *MongoDBManager) GetData(
 	return result, err
 }
 
+// GetUploadTime reads only the stored document's upload_time stamp, for the
+// conditional (?known_upload_time) read path. The projection keeps the implicit
+// _id inclusion so an existing document always yields a non-empty result even
+// when it predates the upload_time stamp; found therefore means "document
+// exists", and uploadTime is 0 when the stamp is missing or non-numeric.
+func (m *MongoDBManager) GetUploadTime(
+	ctx context.Context,
+	userID int64,
+	server string,
+	dataType utils.UploadDataType,
+) (uploadTime int64, found bool, err error) {
+	result, err := m.GetDataWithProjection(ctx, userID, server, dataType, bson.M{fieldUploadTime: 1})
+	if err != nil {
+		return 0, false, err
+	}
+	if len(result) == 0 {
+		return 0, false, nil
+	}
+	return uploadTimeFromResult(result), true, nil
+}
+
+func uploadTimeFromResult(result bson.D) int64 {
+	for _, elem := range result {
+		if elem.Key == fieldUploadTime {
+			parsed, _ := toInt64(elem.Value)
+			return parsed
+		}
+	}
+	return 0
+}
+
 func (m *MongoDBManager) GetDataWithProjection(
 	ctx context.Context,
 	userID int64,

--- a/utils/database/mongo/upload_time_test.go
+++ b/utils/database/mongo/upload_time_test.go
@@ -1,0 +1,48 @@
+package manager
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestUploadTimeFromResult(t *testing.T) {
+	cases := []struct {
+		name   string
+		result bson.D
+		want   int64
+	}{
+		{
+			name:   "int64 stamp",
+			result: bson.D{{Key: "_id", Value: int64(1)}, {Key: "upload_time", Value: int64(1752600000)}},
+			want:   1752600000,
+		},
+		{
+			name:   "int32 stamp from legacy document",
+			result: bson.D{{Key: "_id", Value: int64(1)}, {Key: "upload_time", Value: int32(1234)}},
+			want:   1234,
+		},
+		{
+			name:   "double stamp from legacy document",
+			result: bson.D{{Key: "_id", Value: int64(1)}, {Key: "upload_time", Value: float64(1752600000)}},
+			want:   1752600000,
+		},
+		{
+			name:   "document without stamp",
+			result: bson.D{{Key: "_id", Value: int64(1)}},
+			want:   0,
+		},
+		{
+			name:   "non-numeric stamp",
+			result: bson.D{{Key: "_id", Value: int64(1)}, {Key: "upload_time", Value: bson.D{}}},
+			want:   0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := uploadTimeFromResult(tc.result); got != tc.want {
+				t.Fatalf("uploadTimeFromResult(%v) = %d, want %d", tc.result, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

给 public / OAuth2 / private 三个 game-data 读端点加条件拉取：请求附带 `?known_upload_time=<unix 秒>`，若与存储文档的 `upload_time` 一致，直接返回 `304 Not Modified`（空响应体 + `X-Upload-Time` 头）。下游原本的"先探测 `upload_time` 再拉全量"两跳合并为一跳，未变化时不再传输全量数据。

> 基于 #56（叠加 PR，改的是同一批读路径文件）；#56 合并后本 PR 会自动重指向 main。

## 设计要点

- **纯优化，无新失败模式**：仅在各面完整鉴权之后运行；参数非法按未携带处理（类比不可解析的 `If-Modified-Since`）；文档缺失/无戳/Mongo 错误一律降级到原全量路径。
- **戳与 body 永远一致**：`X-Upload-Time` 只在 304 时返回；完整响应的时间戳一律以响应体的 `upload_time` 字段为准（Redis body 缓存可能短暂落后上传，来自新鲜 Mongo 读的头部值曾被审查证实会把旧 body"钉死"到下一次上传——已按此重新设计）。
- **304 只在与全量路径不可能分叉时给出**：
  - 非空 `key` 过滤必须包含 `upload_time`（否则允许列表面上存在文档可投影为空 → 全量路径 404，且客户端无法维护本地戳）；
  - public/OAuth2 suite 面要求 `upload_time` 在 `public_api_allowed_keys` 中（否则 304/200 构成运营方有意隐藏的时间戳等值预言机），且 `key` 过滤必须合法（无效 key 照常 400）；
  - private 面跳过 `$`/空段/点号 key（保留原有 Mongo 投影行为与错误语义）；
  - 同秒守卫：戳所在秒未完全过去不给 304（同秒覆盖窗口内不会误判）。
- 条件判断用 `{upload_time:1}` 投影走 `_id` 主键索引（约 1–2ms），保留隐式 `_id` 以区分"文档不存在"与"字段缺失"。
- key 校验逻辑抽为 `InvalidSuiteRequestKey` / `InvalidMysekaiRequestKey`，原 handler 与条件闸门共用同一实现（行为逐字节一致，含 `userGamedata` 豁免、空段、错误文案）。

## 已知边界（有意保留）

时间戳精度为 unix 秒：同一秒内两次上传在极端时序下仍可能被 304 吞掉一轮——该窗口与现有两跳探测方式**完全同级**（旧 probe 拿到相同戳同样会跳过重拉），彻底关闭需要把 `upload_time` 改为持久化时单调递增或引入版本号，会改变上传数据语义，未在本 PR 内改动。文档已注明该精度限制。

## 验证

- 两轮多 agent 对抗审查：第一轮 4 视角 ×2 怀疑者确认 9 项问题 → 按根因重新设计（头部仅 304、白名单闸门、同秒守卫、key 先验）；第二轮 3 验证员确认原问题全部消除、fetch.go 重构无行为漂移、fiber/fasthttp 304 空体路径与压缩中间件兼容、文档与实现契约一致。
- `gofmt` / `go build` / `go vet` / `staticcheck` / `go test -count=1 ./...` 全绿；新增 `notModifiedDecision`、key 校验器、BSON 戳提取的单元测试。

## 文档

- `docs/oauth2-client-integration.zh-CN.md`：§7.3 新增条件拉取契约（含精度限制与 key 过滤要求）。
- `docs/webhook-integration.zh-CN.md`：接入建议新增轮询回源时的条件拉取用法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)