### PR TITLE
[Fix] Correct game-binding not-found status and trim upload log noise

### DIFF
--- a/internal/modules/upload/ios.go
+++ b/internal/modules/upload/ios.go
@@ -256,7 +256,12 @@ func handleIOSScriptUploadWithValidation(apiHelper *harukiAPIHelper.HarukiToolbo
 			defer cancel()
 			_, err := HandleUpload(uploadCtx, payload, server, harukiUtils.UploadDataType(uploadType), &userId, &toolboxUserID, apiHelper, harukiUtils.UploadMethodIOSScript)
 			if err != nil {
-				logger.Errorf("HandleUpload failed: %v", err)
+				// HandleUpload already logs every failure with full context at
+				// WARNING inside its fail() helper. This async fire-and-forget
+				// path has no response to return the error on, so it only needs
+				// a debug breadcrumb — re-logging at ERROR duplicated the line
+				// and inflated the error rate with routine user-input failures.
+				logger.Debugf("async HandleUpload finished with error: %v", err)
 			}
 		}(completedChunks, gameUserId, server, string(uploadType), toolboxUserIDCopy)
 		return harukiAPIHelper.SuccessResponse[string](c, "Successfully uploaded data.", nil)

--- a/internal/modules/usergamebindings/gameaccount_profile_verify.go
+++ b/internal/modules/usergamebindings/gameaccount_profile_verify.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
+	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/sekaiapi"
 
 	"github.com/bytedance/sonic"
 )
@@ -19,10 +20,33 @@ var (
 	errGameAccountProfileInvalid       = errors.New("invalid game account profile response")
 )
 
+// classifyGameAccountProfileError maps the (result, error) pair returned by the
+// Sekai profile client onto a sentinel. For definitive upstream conditions
+// (server in maintenance, account does not exist) the client returns a
+// structured result *alongside* an error; those are user/upstream states, not
+// transport failures, so they must be classified from the result before the
+// error is treated as a generic request failure. Without this, a non-existent
+// game UID surfaces as a 5xx (logged at ERROR) instead of a 400 "game account
+// not found" (logged at INFO). Mirrors sendOwnedGameAccountProfile.
+func classifyGameAccountProfileError(resultInfo *sekaiapi.HarukiSekaiAPIResult, err error) error {
+	if err == nil {
+		return nil
+	}
+	if resultInfo != nil {
+		if !resultInfo.ServerAvailable {
+			return errGameAccountServerUnavailable
+		}
+		if !resultInfo.AccountExists {
+			return errGameAccountNotFound
+		}
+	}
+	return fmt.Errorf("%w: %v", errGameAccountProfileRequestFailed, err)
+}
+
 func verifyGameAccountOwnership(ctx context.Context, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, gameUserIDStr, serverStr, expectedCode string) error {
 	resultInfo, body, err := apiHelper.SekaiAPIClient.GetUserProfile(ctx, gameUserIDStr, serverStr)
 	if err != nil {
-		return fmt.Errorf("%w: %v", errGameAccountProfileRequestFailed, err)
+		return classifyGameAccountProfileError(resultInfo, err)
 	}
 	if resultInfo == nil {
 		return errGameAccountProfileRequestFailed

--- a/internal/modules/usergamebindings/gameaccount_profile_verify_test.go
+++ b/internal/modules/usergamebindings/gameaccount_profile_verify_test.go
@@ -1,0 +1,81 @@
+package usergamebindings
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/sekaiapi"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// The Sekai profile client returns a structured result alongside its error for
+// definitive upstream conditions. classifyGameAccountProfileError must prefer
+// that structured classification so a non-existent game UID becomes a 400
+// (logged at INFO), not a 5xx (logged at ERROR).
+func TestClassifyGameAccountProfileError(t *testing.T) {
+	t.Parallel()
+
+	upstream := errors.New("this user does not exist: user not found")
+
+	cases := []struct {
+		name       string
+		resultInfo *sekaiapi.HarukiSekaiAPIResult
+		err        error
+		wantErr    error // sentinel expected via errors.Is; nil means the wrapped generic failure
+		wantCode   int   // resulting fiber code after mapGameAccountOwnershipVerificationError
+	}{
+		{
+			name:    "no error passes through",
+			err:     nil,
+			wantErr: nil,
+		},
+		{
+			name:       "account missing is classified as not found",
+			resultInfo: &sekaiapi.HarukiSekaiAPIResult{ServerAvailable: true, AccountExists: false},
+			err:        upstream,
+			wantErr:    errGameAccountNotFound,
+			wantCode:   fiber.StatusBadRequest,
+		},
+		{
+			name:       "server unavailable takes precedence",
+			resultInfo: &sekaiapi.HarukiSekaiAPIResult{ServerAvailable: false, AccountExists: false},
+			err:        errors.New("game server under maintenance"),
+			wantErr:    errGameAccountServerUnavailable,
+			wantCode:   fiber.StatusBadGateway,
+		},
+		{
+			name:       "reachable account with error is a generic request failure",
+			resultInfo: &sekaiapi.HarukiSekaiAPIResult{ServerAvailable: true, AccountExists: true},
+			err:        errors.New("connection reset"),
+			wantErr:    errGameAccountProfileRequestFailed,
+			wantCode:   fiber.StatusBadGateway,
+		},
+		{
+			name:     "nil result falls back to generic request failure",
+			err:      errors.New("dial timeout"),
+			wantErr:  errGameAccountProfileRequestFailed,
+			wantCode: fiber.StatusBadGateway,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyGameAccountProfileError(tc.resultInfo, tc.err)
+			if tc.wantErr == nil {
+				if got != nil {
+					t.Fatalf("classifyGameAccountProfileError() = %v, want nil", got)
+				}
+				return
+			}
+			if !errors.Is(got, tc.wantErr) {
+				t.Fatalf("classifyGameAccountProfileError() = %v, want errors.Is(_, %v)", got, tc.wantErr)
+			}
+			if mapped := mapGameAccountOwnershipVerificationError(got); mapped.Code != tc.wantCode {
+				t.Fatalf("mapped code = %d, want %d", mapped.Code, tc.wantCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

Post-deploy production log review of v8.4.0 found the ERROR/WARNING stream is dominated by **routine user-input failures**, not real faults. Two small, safe fixes address the two biggest offenders. No behavior change for the happy path; no touching of the inherit retriever's sleeps/mimicry.

## Changes

### 1. Game-account binding: non-existent UID was a 5xx, now a 4xx (correctness + log level)
`verifyGameAccountOwnership` returned the Sekai client error as a generic `errGameAccountProfileRequestFailed` (→ **502**, logged at **ERROR**) even when the client's structured result already reported `AccountExists=false`. The client returns a result *alongside* the error for definitive upstream states (404 not-exist, 503 maintenance), so the result must be consulted first.

- A user entering a wrong/non-existent game UID now gets **400 "game account not found"** (logged at **INFO**), instead of a 502 logged at ERROR.
- Logic extracted into a pure, unit-tested `classifyGameAccountProfileError` helper.
- This makes `verifyGameAccountOwnership` consistent with the already-correct `sendOwnedGameAccountProfile` in the same module.

### 2. Async iOS upload: duplicate ERROR log demoted to DEBUG
The fire-and-forget iOS-script upload goroutine re-logged every failure at **ERROR** with no added context, duplicating the **WARNING** that `HandleUpload`'s `fail()` helper already emits with full structured context. In 6h of prod logs this single line produced the bulk of ERROR noise (e.g. `no userMysekaiHarvestMaps found ... not participated in the birthday party event yet`). Demoted to a DEBUG breadcrumb. Synchronous callers (manual/harukiproxy/inherit) already map the error to an HTTP response and are unaffected.

## Testing

- `gofmt -l` clean, `go build ./...`, `go vet`, `staticcheck` (2025.1.1) all clean on affected packages
- `go test -race -count=1 ./internal/modules/usergamebindings/ ./internal/modules/upload/` — pass
- New `TestClassifyGameAccountProfileError` covers not-found → 400, maintenance → 502, reachable-with-error → 502, and nil-result fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game account verification error handling to distinguish unavailable services, missing accounts, and unexpected request failures.
  * Updated asynchronous upload failure logging to reduce redundant high-severity error reports.

* **Tests**
  * Added coverage for game account verification outcomes and their corresponding HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->