### PR TITLE
[Feat] Add owned account conditional data reads

### DIFF
--- a/docs/game-account-data-grants.zh-CN.md
+++ b/docs/game-account-data-grants.zh-CN.md
@@ -59,4 +59,6 @@ DELETE /api/user/:toolbox_user_id/game-account-grants/:server/:game_user_id/:dat
 - `GET /api/user/:toolbox_user_id/game-account/:server/:game_user_id/:data_type`
 - `GET /api/oauth2/game-data/:server/:data_type/:user_id`
 
+浏览器 owned-account 入口的 `suite` / `mysekai` 读取可附带 `known_upload_time=<上次完整响应中的 upload_time>`。数据未变化时返回 `304 Not Modified`；若使用 `key` 过滤，必须同时包含 `upload_time`。该优化在所有权或授权校验完成后运行，不改变授权范围及错误语义。
+
 OAuth2 入口仍要求 token scope 包含 `game-data:read`。授权不会改变 public API、private token API、Redis 数据缓存 key 或 Mongo 数据形状。

--- a/docs/ory-suite-usage.zh-CN.md
+++ b/docs/ory-suite-usage.zh-CN.md
@@ -315,6 +315,9 @@ Hydra 在当前项目里负责：
 - `GET /api/user/:toolbox_user_id/game-account/:server/:game_user_id/:data_type`
 - `:data_type` 允许 `suite`、`mysekai`、`profile`
 - `suite` 和 `mysekai` 复用 public API / OAuth2 game-data 的数据读取逻辑，并支持 `key` 查询参数
+- `suite` 和 `mysekai` 支持 `known_upload_time=<上次完整响应中的 upload_time>` 条件读取；数据未变化时返回 `304 Not Modified`、空响应体和 `X-Upload-Time` 响应头
+- 使用 `key` 过滤时必须同时请求 `upload_time` 才可能返回 304；suite 的公开字段允许列表不包含 `upload_time` 时也会回退到完整响应
+- 完整响应的时间戳始终以响应体 `upload_time` 为准；时间戳精度为 unix 秒，同一秒内多次上传无法区分
 - `profile` 通过 Haruki Sekai API 读取绑定账号 profile，并直接透传 JSON 响应体
 - 该接口会校验浏览器登录态、`:toolbox_user_id` 是否为当前用户、账号绑定是否属于当前用户且已验证；`suite` / `mysekai` 也允许通过有效的游戏账号数据授权读取
 - `suite` 数据会保留 `userGamedata.userId` number 字段，并额外返回 `userGamedata.userIdString` 字符串镜像；前端应优先使用字符串字段避免 64 位整数精度丢失

--- a/internal/modules/usergamebindings/game_account_data.go
+++ b/internal/modules/usergamebindings/game_account_data.go
@@ -87,15 +87,23 @@ func handleGetOwnedGameAccountData(apiHelper *harukiAPIHelper.HarukiToolboxRoute
 			return harukiAPIHelper.ErrorForbidden(c, "not authorized to access this binding")
 		}
 
+		requestKey := c.Query("key")
 		switch dataType {
 		case ownedGameAccountDataTypeSuite:
-			resp, err := handleOwnedSuiteData(ctx, c, apiHelper, gameUserID, server)
+			allowedKeySet, allowedKeys := buildPublicAPIAllowedKeySet(apiHelper)
+			if ownedGameAccountNotModified(ctx, c, apiHelper, gameUserID, server, harukiUtils.UploadDataTypeSuite, requestKey, true, allowedKeys) {
+				return c.SendStatus(fiber.StatusNotModified)
+			}
+			resp, err := data.HandleSuiteRequest(ctx, apiHelper, gameUserID, server, requestKey, allowedKeySet, allowedKeys)
 			if err != nil {
 				return respondVerifiedGameAccountDataError(c, err)
 			}
 			return c.JSON(resp)
 		case ownedGameAccountDataTypeMysekai:
-			resp, err := data.HandleMysekaiRequest(ctx, apiHelper, gameUserID, server, c.Query("key"))
+			if ownedGameAccountNotModified(ctx, c, apiHelper, gameUserID, server, harukiUtils.UploadDataTypeMysekai, requestKey, false, nil) {
+				return c.SendStatus(fiber.StatusNotModified)
+			}
+			resp, err := data.HandleMysekaiRequest(ctx, apiHelper, gameUserID, server, requestKey)
 			if err != nil {
 				return respondVerifiedGameAccountDataError(c, err)
 			}
@@ -111,9 +119,26 @@ func handleGetOwnedGameAccountData(apiHelper *harukiAPIHelper.HarukiToolboxRoute
 	}
 }
 
-func handleOwnedSuiteData(ctx context.Context, c fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, gameUserID int64, server harukiUtils.SupportedDataUploadServer) (any, error) {
-	allowedKeySet, allowedKeys := buildPublicAPIAllowedKeySet(apiHelper)
-	return data.HandleSuiteRequest(ctx, apiHelper, gameUserID, server, c.Query("key"), allowedKeySet, allowedKeys)
+func ownedGameAccountNotModified(
+	ctx context.Context,
+	c fiber.Ctx,
+	apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers,
+	gameUserID int64,
+	server harukiUtils.SupportedDataUploadServer,
+	dataType harukiUtils.UploadDataType,
+	requestKey string,
+	publicKeyFiltered bool,
+	publicAllowedKeys []string,
+) bool {
+	if data.ParseKnownUploadTime(c.Query(data.QueryKnownUploadTime)) <= 0 {
+		return false
+	}
+	stamp, confirmed, err := data.ResolveGameDataStamp(ctx, apiHelper, server, dataType, gameUserID)
+	if err != nil {
+		harukiLogger.Warnf("Failed to resolve owned game account data stamp (server=%s,data_type=%s,user_id=%d): %v", server, dataType, gameUserID, err)
+		return false
+	}
+	return confirmed && data.CheckNotModified(c, dataType, requestKey, publicKeyFiltered, publicAllowedKeys, stamp)
 }
 
 func sendOwnedGameAccountProfile(c fiber.Ctx, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, gameUserIDStr string, server harukiUtils.SupportedDataUploadServer) error {

--- a/internal/modules/usergamebindings/game_account_data_test.go
+++ b/internal/modules/usergamebindings/game_account_data_test.go
@@ -1,7 +1,9 @@
 package usergamebindings
 
 import (
+	"context"
 	userCoreModule "github.com/Team-Haruki/Haruki-Toolbox-Backend/internal/modules/usercore"
+	harukiUtils "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils"
 	"net/http/httptest"
 	"testing"
 
@@ -41,6 +43,42 @@ func TestParseOwnedGameAccountDataType(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Fatalf("data type = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOwnedGameAccountConditionalReadIgnoresMissingOrInvalidStamp(t *testing.T) {
+	t.Parallel()
+
+	for _, query := range []string{"", "?known_upload_time=invalid", "?known_upload_time=0"} {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			app := fiber.New()
+			app.Get("/data", func(c fiber.Ctx) error {
+				if ownedGameAccountNotModified(
+					context.Background(),
+					c,
+					nil,
+					123,
+					harukiUtils.SupportedDataUploadServerJP,
+					harukiUtils.UploadDataTypeSuite,
+					"",
+					true,
+					[]string{"upload_time"},
+				) {
+					t.Fatal("invalid or missing stamp must not produce 304")
+				}
+				return c.SendStatus(fiber.StatusOK)
+			})
+
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/data"+query, nil))
+			if err != nil {
+				t.Fatalf("app.Test returned error: %v", err)
+			}
+			if resp.StatusCode != fiber.StatusOK {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, fiber.StatusOK)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- add `known_upload_time` conditional reads to authenticated owned-account `suite` and `mysekai` endpoints
- return `304 Not Modified` only after ownership/grant authorization and a confirmed game-data stamp
- preserve the existing full-response and profile behavior, including suite allowlist constraints
- document the owned-account conditional-read contract

## Impact

Toolbox clients can replace the previous upload-time probe plus full fetch with a single conditional request. Unchanged data returns an empty 304 response with `X-Upload-Time`; legacy and unsupported cases continue through the existing 200/error path.

## Validation

- `gofmt`
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...` using CI version `2026.1`
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional caching for browser game-account data requests.
  * Requests with a matching `known_upload_time` can now receive `304 Not Modified`, including the relevant upload timestamp header.
  * Added support for conditional reads with `key` filtering when `upload_time` is requested.

* **Documentation**
  * Updated Chinese documentation to explain caching behavior, validation requirements, response details, and timestamp precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->