### PR TITLE
[Feat] Add default game account binding

### DIFF
--- a/ent/toolbox/schema/gameaccountbinding.go
+++ b/ent/toolbox/schema/gameaccountbinding.go
@@ -18,6 +18,10 @@ func (GameAccountBinding) Fields() []ent.Field {
 		field.String("server").Comment("jp | en | tw | kr | cn"),
 		field.String("game_user_id"),
 		field.Bool("verified").Default(false),
+		// At most one binding per user carries is_default=true (the user's
+		// global default account); enforced in application transactions, not by
+		// a DB constraint, so legacy rows may simply all be false.
+		field.Bool("is_default").Default(false),
 		field.JSON("suite", &SuiteDataPrivacySettings{}).Optional(),
 		field.JSON("mysekai", &MysekaiDataPrivacySettings{}).Optional(),
 	}

--- a/internal/modules/adminusers/user_integrations_helpers.go
+++ b/internal/modules/adminusers/user_integrations_helpers.go
@@ -185,11 +185,12 @@ func buildAdminGameBindingItems(rows []*postgresql.GameAccountBinding) []harukiA
 	items := make([]harukiAPIHelper.GameAccountBinding, 0, len(rows))
 	for _, row := range rows {
 		items = append(items, harukiAPIHelper.GameAccountBinding{
-			Server:   harukiUtils.SupportedDataUploadServer(row.Server),
-			UserID:   row.GameUserID,
-			Verified: row.Verified,
-			Suite:    row.Suite,
-			Mysekai:  row.Mysekai,
+			Server:    harukiUtils.SupportedDataUploadServer(row.Server),
+			UserID:    row.GameUserID,
+			Verified:  row.Verified,
+			IsDefault: row.IsDefault,
+			Suite:     row.Suite,
+			Mysekai:   row.Mysekai,
 		})
 	}
 	return items

--- a/internal/modules/usergamebindings/gameaccount_default_test.go
+++ b/internal/modules/usergamebindings/gameaccount_default_test.go
@@ -1,0 +1,134 @@
+package usergamebindings
+
+import (
+	"context"
+	"testing"
+
+	harukiSchema "github.com/Team-Haruki/Haruki-Toolbox-Backend/ent/toolbox/schema"
+	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
+	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database"
+	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql"
+	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/enttest"
+	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/gameaccountbinding"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newDefaultBindingTestHelper(t *testing.T, dbName string) (*harukiAPIHelper.HarukiToolboxRouterHelpers, *postgresql.Client, context.Context) {
+	t.Helper()
+	client := enttest.Open(t, "sqlite3", "file:"+dbName+"?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	helper := &harukiAPIHelper.HarukiToolboxRouterHelpers{
+		DBManager: &database.HarukiToolboxDBManager{DB: client},
+	}
+	return helper, client, context.Background()
+}
+
+func createDefaultBindingTestUser(t *testing.T, client *postgresql.Client, ctx context.Context, id string) {
+	t.Helper()
+	if _, err := client.User.Create().
+		SetID(id).
+		SetName(id).
+		SetEmail(id + "@example.com").
+		Save(ctx); err != nil {
+		t.Fatalf("create user %s returned error: %v", id, err)
+	}
+}
+
+func createBindingViaSave(t *testing.T, helper *harukiAPIHelper.HarukiToolboxRouterHelpers, ctx context.Context, server, gameUserID, owner string) {
+	t.Helper()
+	if _, err := saveGameAccountBinding(ctx, helper, nil, server, gameUserID, owner, harukiAPIHelper.CreateGameAccountBindingPayload{
+		Suite:   &harukiSchema.SuiteDataPrivacySettings{},
+		MySekai: &harukiSchema.MysekaiDataPrivacySettings{},
+	}); err != nil {
+		t.Fatalf("saveGameAccountBinding(%s/%s) returned error: %v", server, gameUserID, err)
+	}
+}
+
+func queryBindingIsDefault(t *testing.T, client *postgresql.Client, ctx context.Context, server, gameUserID string) bool {
+	t.Helper()
+	binding, err := client.GameAccountBinding.Query().
+		Where(
+			gameaccountbinding.ServerEQ(server),
+			gameaccountbinding.GameUserIDEQ(gameUserID),
+		).
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("query binding %s/%s returned error: %v", server, gameUserID, err)
+	}
+	return binding.IsDefault
+}
+
+func TestFirstBindingBecomesDefaultAndLaterOnesDoNot(t *testing.T) {
+	helper, client, ctx := newDefaultBindingTestHelper(t, "binding-default-first")
+	createDefaultBindingTestUser(t, client, ctx, "owner")
+
+	createBindingViaSave(t, helper, ctx, "jp", "111", "owner")
+	createBindingViaSave(t, helper, ctx, "cn", "222", "owner")
+
+	if !queryBindingIsDefault(t, client, ctx, "jp", "111") {
+		t.Fatalf("first binding should become the default")
+	}
+	if queryBindingIsDefault(t, client, ctx, "cn", "222") {
+		t.Fatalf("second binding must not steal the default")
+	}
+}
+
+func TestTransferredBindingDropsPreviousOwnersDefaultFlag(t *testing.T) {
+	helper, client, ctx := newDefaultBindingTestHelper(t, "binding-default-transfer")
+	createDefaultBindingTestUser(t, client, ctx, "old-owner")
+	createDefaultBindingTestUser(t, client, ctx, "new-owner")
+
+	// old-owner's first (and default) binding; new-owner already has a default.
+	createBindingViaSave(t, helper, ctx, "jp", "111", "old-owner")
+	createBindingViaSave(t, helper, ctx, "jp", "999", "new-owner")
+
+	existing, err := client.GameAccountBinding.Query().
+		Where(gameaccountbinding.GameUserIDEQ("111")).
+		WithUser().
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("query existing binding returned error: %v", err)
+	}
+	if _, err := saveGameAccountBinding(ctx, helper, existing, "jp", "111", "new-owner", harukiAPIHelper.CreateGameAccountBindingPayload{
+		Suite:   &harukiSchema.SuiteDataPrivacySettings{},
+		MySekai: &harukiSchema.MysekaiDataPrivacySettings{},
+	}); err != nil {
+		t.Fatalf("transfer saveGameAccountBinding returned error: %v", err)
+	}
+
+	if queryBindingIsDefault(t, client, ctx, "jp", "111") {
+		t.Fatalf("transferred binding must not keep the previous owner's default flag")
+	}
+	if !queryBindingIsDefault(t, client, ctx, "jp", "999") {
+		t.Fatalf("new owner's existing default must survive the transfer")
+	}
+}
+
+func TestTransferredBindingBecomesDefaultWhenNewOwnerHasNone(t *testing.T) {
+	helper, client, ctx := newDefaultBindingTestHelper(t, "binding-default-transfer-empty")
+	createDefaultBindingTestUser(t, client, ctx, "old-owner")
+	createDefaultBindingTestUser(t, client, ctx, "new-owner")
+
+	createBindingViaSave(t, helper, ctx, "jp", "111", "old-owner")
+
+	existing, err := client.GameAccountBinding.Query().
+		Where(gameaccountbinding.GameUserIDEQ("111")).
+		WithUser().
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("query existing binding returned error: %v", err)
+	}
+	if _, err := saveGameAccountBinding(ctx, helper, existing, "jp", "111", "new-owner", harukiAPIHelper.CreateGameAccountBindingPayload{
+		Suite:   &harukiSchema.SuiteDataPrivacySettings{},
+		MySekai: &harukiSchema.MysekaiDataPrivacySettings{},
+	}); err != nil {
+		t.Fatalf("transfer saveGameAccountBinding returned error: %v", err)
+	}
+
+	if !queryBindingIsDefault(t, client, ctx, "jp", "111") {
+		t.Fatalf("binding transferred to an owner without a default should become their default")
+	}
+}

--- a/internal/modules/usergamebindings/gameaccount_handlers.go
+++ b/internal/modules/usergamebindings/gameaccount_handlers.go
@@ -11,6 +11,7 @@ import (
 	harukiAPIHelper "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/api"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql"
 	"github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/gameaccountbinding"
+	userSchema "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/postgresql/user"
 	harukiRedis "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/database/redis"
 	harukiLogger "github.com/Team-Haruki/Haruki-Toolbox-Backend/utils/logger"
 	"strings"
@@ -268,14 +269,56 @@ func handleUpdateGameAccountBinding(apiHelper *harukiAPIHelper.HarukiToolboxRout
 			return harukiAPIHelper.ErrorBadRequest(c, "binding is not verified yet")
 		}
 
-		_, err = existing.Update().
-			SetSuite(req.Suite).
-			SetMysekai(req.MySekai).
-			Save(ctx)
-		if err != nil {
-			harukiLogger.Errorf("Failed to update game account binding: %v", err)
-			reason = "update_binding_failed"
-			return harukiAPIHelper.ErrorInternal(c, "failed to update binding")
+		if req.IsDefault != nil && *req.IsDefault {
+			// Making this binding the default clears the flag from every other
+			// binding of the user inside one transaction.
+			tx, txErr := apiHelper.DBManager.DB.Tx(ctx)
+			if txErr != nil {
+				harukiLogger.Errorf("Failed to open transaction for binding update: %v", txErr)
+				reason = "update_binding_failed"
+				return harukiAPIHelper.ErrorInternal(c, "failed to update binding")
+			}
+			if _, txErr = tx.GameAccountBinding.Update().
+				Where(
+					gameaccountbinding.HasUserWith(userSchema.IDEQ(userID)),
+					gameaccountbinding.IsDefaultEQ(true),
+					gameaccountbinding.IDNEQ(existing.ID),
+				).
+				SetIsDefault(false).
+				Save(ctx); txErr != nil {
+				_ = tx.Rollback()
+				harukiLogger.Errorf("Failed to clear previous default binding: %v", txErr)
+				reason = "update_binding_failed"
+				return harukiAPIHelper.ErrorInternal(c, "failed to update binding")
+			}
+			if _, txErr = tx.GameAccountBinding.UpdateOneID(existing.ID).
+				SetSuite(req.Suite).
+				SetMysekai(req.MySekai).
+				SetIsDefault(true).
+				Save(ctx); txErr != nil {
+				_ = tx.Rollback()
+				harukiLogger.Errorf("Failed to update game account binding: %v", txErr)
+				reason = "update_binding_failed"
+				return harukiAPIHelper.ErrorInternal(c, "failed to update binding")
+			}
+			if txErr = tx.Commit(); txErr != nil {
+				_ = tx.Rollback()
+				harukiLogger.Errorf("Failed to commit binding update: %v", txErr)
+				reason = "update_binding_failed"
+				return harukiAPIHelper.ErrorInternal(c, "failed to update binding")
+			}
+		} else {
+			update := existing.Update().
+				SetSuite(req.Suite).
+				SetMysekai(req.MySekai)
+			if req.IsDefault != nil {
+				update = update.SetIsDefault(false)
+			}
+			if _, err = update.Save(ctx); err != nil {
+				harukiLogger.Errorf("Failed to update game account binding: %v", err)
+				reason = "update_binding_failed"
+				return harukiAPIHelper.ErrorInternal(c, "failed to update binding")
+			}
 		}
 		clearGameAccountPublicCaches(ctx, apiHelper, serverStr, gameUserIDStr)
 

--- a/internal/modules/usergamebindings/gameaccount_store.go
+++ b/internal/modules/usergamebindings/gameaccount_store.go
@@ -43,14 +43,29 @@ func getUserBindings(ctx context.Context, apiHelper *harukiAPIHelper.HarukiToolb
 	var resp []harukiAPIHelper.GameAccountBinding
 	for _, b := range bindings {
 		resp = append(resp, harukiAPIHelper.GameAccountBinding{
-			Server:   utils.SupportedDataUploadServer(b.Server),
-			UserID:   b.GameUserID,
-			Verified: b.Verified,
-			Suite:    b.Suite,
-			Mysekai:  b.Mysekai,
+			Server:    utils.SupportedDataUploadServer(b.Server),
+			UserID:    b.GameUserID,
+			Verified:  b.Verified,
+			IsDefault: b.IsDefault,
+			Suite:     b.Suite,
+			Mysekai:   b.Mysekai,
 		})
 	}
 	return resp, nil
+}
+
+// userHasOtherDefaultBinding reports whether the user owns a default-marked
+// binding other than excludeBindingID (pass 0 to consider all bindings).
+func userHasOtherDefaultBinding(ctx context.Context, client *postgresql.Client, userID string, excludeBindingID int) (bool, error) {
+	query := client.GameAccountBinding.Query().
+		Where(
+			gameaccountbinding.HasUserWith(userSchema.IDEQ(strings.TrimSpace(userID))),
+			gameaccountbinding.IsDefaultEQ(true),
+		)
+	if excludeBindingID != 0 {
+		query = query.Where(gameaccountbinding.IDNEQ(excludeBindingID))
+	}
+	return query.Exist(ctx)
 }
 
 func queryExistingBinding(ctx context.Context, apiHelper *harukiAPIHelper.HarukiToolboxRouterHelpers, serverStr, gameUserIDStr string) (*postgresql.GameAccountBinding, error) {
@@ -99,14 +114,22 @@ func saveGameAccountBinding(ctx context.Context, apiHelper *harukiAPIHelper.Haru
 			}
 		}
 
+		hasOtherDefault, err := userHasOtherDefaultBinding(ctx, apiHelper.DBManager.DB, userID, existing.ID)
+		if err != nil {
+			return nil, err
+		}
+
 		tx, err := apiHelper.DBManager.DB.Tx(ctx)
 		if err != nil {
 			return nil, err
 		}
+		// A (re)bound account never keeps a previous owner's default flag; it
+		// becomes the new owner's default only when they have none yet.
 		update := tx.GameAccountBinding.UpdateOneID(existing.ID).
 			SetVerified(true).
 			SetSuite(req.Suite).
 			SetMysekai(req.MySekai).
+			SetIsDefault(!hasOtherDefault).
 			SetUserID(userID)
 		if _, err = update.Save(ctx); err != nil {
 			_ = tx.Rollback()
@@ -131,13 +154,19 @@ func saveGameAccountBinding(ctx context.Context, apiHelper *harukiAPIHelper.Haru
 		return result, nil
 	}
 
-	_, err := apiHelper.DBManager.DB.GameAccountBinding.
+	hasDefault, err := userHasOtherDefaultBinding(ctx, apiHelper.DBManager.DB, userID, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = apiHelper.DBManager.DB.GameAccountBinding.
 		Create().
 		SetServer(serverStr).
 		SetGameUserID(gameUserIDStr).
 		SetVerified(true).
 		SetSuite(req.Suite).
 		SetMysekai(req.MySekai).
+		SetIsDefault(!hasDefault).
 		SetUserID(userID).
 		Save(ctx)
 	if err != nil {

--- a/internal/modules/userprivateapi/game_bindings_handler.go
+++ b/internal/modules/userprivateapi/game_bindings_handler.go
@@ -88,6 +88,7 @@ func handleGetGameBindings(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers
 		type bindingEntry struct {
 			Server     string `json:"server"`
 			GameUserID string `json:"gameUserId"`
+			IsDefault  bool   `json:"isDefault"`
 		}
 		type bindingKey struct {
 			Server     string
@@ -111,6 +112,7 @@ func handleGetGameBindings(apiHelper *harukiApiHelper.HarukiToolboxRouterHelpers
 				result = append(result, bindingEntry{
 					Server:     b.Server,
 					GameUserID: b.GameUserID,
+					IsDefault:  b.IsDefault,
 				})
 			}
 			return nil

--- a/utils/api/struct.go
+++ b/utils/api/struct.go
@@ -95,6 +95,9 @@ type GameAccountBindingPayload struct {
 type CreateGameAccountBindingPayload struct {
 	Suite   *schema.SuiteDataPrivacySettings   `json:"suite"`
 	MySekai *schema.MysekaiDataPrivacySettings `json:"mysekai"`
+	// Optional: when set, marks (true) or unmarks (false) this binding as the
+	// user's global default account. Omitted -> unchanged.
+	IsDefault *bool `json:"isDefault"`
 }
 
 type RegisterOrLoginSuccessResponse struct {
@@ -143,11 +146,12 @@ type AuthorizeSocialPlatformInfo struct {
 }
 
 type GameAccountBinding struct {
-	Server   utils.SupportedDataUploadServer    `json:"server"`
-	UserID   string                             `json:"userId"`
-	Verified bool                               `json:"verified"`
-	Suite    *schema.SuiteDataPrivacySettings   `json:"suite,omitempty"`
-	Mysekai  *schema.MysekaiDataPrivacySettings `json:"mysekai,omitempty"`
+	Server    utils.SupportedDataUploadServer    `json:"server"`
+	UserID    string                             `json:"userId"`
+	Verified  bool                               `json:"verified"`
+	IsDefault bool                               `json:"isDefault"`
+	Suite     *schema.SuiteDataPrivacySettings   `json:"suite,omitempty"`
+	Mysekai   *schema.MysekaiDataPrivacySettings `json:"mysekai,omitempty"`
 }
 
 type GenerateSocialPlatformCodeResponse struct {

--- a/utils/api/userdata.go
+++ b/utils/api/userdata.go
@@ -94,11 +94,12 @@ func buildGameAccountBindingsFromUser(user *postgresql.User) []GameAccountBindin
 		result = make([]GameAccountBinding, 0, len(user.Edges.GameAccountBindings))
 		for _, g := range user.Edges.GameAccountBindings {
 			result = append(result, GameAccountBinding{
-				Server:   utils.SupportedDataUploadServer(g.Server),
-				UserID:   g.GameUserID,
-				Verified: g.Verified,
-				Suite:    g.Suite,
-				Mysekai:  g.Mysekai,
+				Server:    utils.SupportedDataUploadServer(g.Server),
+				UserID:    g.GameUserID,
+				Verified:  g.Verified,
+				IsDefault: g.IsDefault,
+				Suite:     g.Suite,
+				Mysekai:   g.Mysekai,
 			})
 		}
 	}

--- a/utils/database/postgresql/gameaccountbinding.go
+++ b/utils/database/postgresql/gameaccountbinding.go
@@ -25,6 +25,8 @@ type GameAccountBinding struct {
 	GameUserID string `json:"game_user_id,omitempty"`
 	// Verified holds the value of the "verified" field.
 	Verified bool `json:"verified,omitempty"`
+	// IsDefault holds the value of the "is_default" field.
+	IsDefault bool `json:"is_default,omitempty"`
 	// Suite holds the value of the "suite" field.
 	Suite *schema.SuiteDataPrivacySettings `json:"suite,omitempty"`
 	// Mysekai holds the value of the "mysekai" field.
@@ -63,7 +65,7 @@ func (*GameAccountBinding) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case gameaccountbinding.FieldSuite, gameaccountbinding.FieldMysekai:
 			values[i] = new([]byte)
-		case gameaccountbinding.FieldVerified:
+		case gameaccountbinding.FieldVerified, gameaccountbinding.FieldIsDefault:
 			values[i] = new(sql.NullBool)
 		case gameaccountbinding.FieldID:
 			values[i] = new(sql.NullInt64)
@@ -109,6 +111,12 @@ func (_m *GameAccountBinding) assignValues(columns []string, values []any) error
 				return fmt.Errorf("unexpected type %T for field verified", values[i])
 			} else if value.Valid {
 				_m.Verified = value.Bool
+			}
+		case gameaccountbinding.FieldIsDefault:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field is_default", values[i])
+			} else if value.Valid {
+				_m.IsDefault = value.Bool
 			}
 		case gameaccountbinding.FieldSuite:
 			if value, ok := values[i].(*[]byte); !ok {
@@ -182,6 +190,9 @@ func (_m *GameAccountBinding) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("verified=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Verified))
+	builder.WriteString(", ")
+	builder.WriteString("is_default=")
+	builder.WriteString(fmt.Sprintf("%v", _m.IsDefault))
 	builder.WriteString(", ")
 	builder.WriteString("suite=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Suite))

--- a/utils/database/postgresql/gameaccountbinding/gameaccountbinding.go
+++ b/utils/database/postgresql/gameaccountbinding/gameaccountbinding.go
@@ -18,6 +18,8 @@ const (
 	FieldGameUserID = "game_user_id"
 	// FieldVerified holds the string denoting the verified field in the database.
 	FieldVerified = "verified"
+	// FieldIsDefault holds the string denoting the is_default field in the database.
+	FieldIsDefault = "is_default"
 	// FieldSuite holds the string denoting the suite field in the database.
 	FieldSuite = "suite"
 	// FieldMysekai holds the string denoting the mysekai field in the database.
@@ -41,6 +43,7 @@ var Columns = []string{
 	FieldServer,
 	FieldGameUserID,
 	FieldVerified,
+	FieldIsDefault,
 	FieldSuite,
 	FieldMysekai,
 }
@@ -69,6 +72,8 @@ func ValidColumn(column string) bool {
 var (
 	// DefaultVerified holds the default value on creation for the "verified" field.
 	DefaultVerified bool
+	// DefaultIsDefault holds the default value on creation for the "is_default" field.
+	DefaultIsDefault bool
 )
 
 // OrderOption defines the ordering options for the GameAccountBinding queries.
@@ -92,6 +97,11 @@ func ByGameUserID(opts ...sql.OrderTermOption) OrderOption {
 // ByVerified orders the results by the verified field.
 func ByVerified(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldVerified, opts...).ToFunc()
+}
+
+// ByIsDefault orders the results by the is_default field.
+func ByIsDefault(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldIsDefault, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.

--- a/utils/database/postgresql/gameaccountbinding/where.go
+++ b/utils/database/postgresql/gameaccountbinding/where.go
@@ -68,6 +68,11 @@ func Verified(v bool) predicate.GameAccountBinding {
 	return predicate.GameAccountBinding(sql.FieldEQ(FieldVerified, v))
 }
 
+// IsDefault applies equality check predicate on the "is_default" field. It's identical to IsDefaultEQ.
+func IsDefault(v bool) predicate.GameAccountBinding {
+	return predicate.GameAccountBinding(sql.FieldEQ(FieldIsDefault, v))
+}
+
 // ServerEQ applies the EQ predicate on the "server" field.
 func ServerEQ(v string) predicate.GameAccountBinding {
 	return predicate.GameAccountBinding(sql.FieldEQ(FieldServer, v))
@@ -206,6 +211,16 @@ func VerifiedEQ(v bool) predicate.GameAccountBinding {
 // VerifiedNEQ applies the NEQ predicate on the "verified" field.
 func VerifiedNEQ(v bool) predicate.GameAccountBinding {
 	return predicate.GameAccountBinding(sql.FieldNEQ(FieldVerified, v))
+}
+
+// IsDefaultEQ applies the EQ predicate on the "is_default" field.
+func IsDefaultEQ(v bool) predicate.GameAccountBinding {
+	return predicate.GameAccountBinding(sql.FieldEQ(FieldIsDefault, v))
+}
+
+// IsDefaultNEQ applies the NEQ predicate on the "is_default" field.
+func IsDefaultNEQ(v bool) predicate.GameAccountBinding {
+	return predicate.GameAccountBinding(sql.FieldNEQ(FieldIsDefault, v))
 }
 
 // SuiteIsNil applies the IsNil predicate on the "suite" field.

--- a/utils/database/postgresql/gameaccountbinding_create.go
+++ b/utils/database/postgresql/gameaccountbinding_create.go
@@ -47,6 +47,20 @@ func (_c *GameAccountBindingCreate) SetNillableVerified(v *bool) *GameAccountBin
 	return _c
 }
 
+// SetIsDefault sets the "is_default" field.
+func (_c *GameAccountBindingCreate) SetIsDefault(v bool) *GameAccountBindingCreate {
+	_c.mutation.SetIsDefault(v)
+	return _c
+}
+
+// SetNillableIsDefault sets the "is_default" field if the given value is not nil.
+func (_c *GameAccountBindingCreate) SetNillableIsDefault(v *bool) *GameAccountBindingCreate {
+	if v != nil {
+		_c.SetIsDefault(*v)
+	}
+	return _c
+}
+
 // SetSuite sets the "suite" field.
 func (_c *GameAccountBindingCreate) SetSuite(v *schema.SuiteDataPrivacySettings) *GameAccountBindingCreate {
 	_c.mutation.SetSuite(v)
@@ -117,6 +131,10 @@ func (_c *GameAccountBindingCreate) defaults() {
 		v := gameaccountbinding.DefaultVerified
 		_c.mutation.SetVerified(v)
 	}
+	if _, ok := _c.mutation.IsDefault(); !ok {
+		v := gameaccountbinding.DefaultIsDefault
+		_c.mutation.SetIsDefault(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -129,6 +147,9 @@ func (_c *GameAccountBindingCreate) check() error {
 	}
 	if _, ok := _c.mutation.Verified(); !ok {
 		return &ValidationError{Name: "verified", err: errors.New(`postgresql: missing required field "GameAccountBinding.verified"`)}
+	}
+	if _, ok := _c.mutation.IsDefault(); !ok {
+		return &ValidationError{Name: "is_default", err: errors.New(`postgresql: missing required field "GameAccountBinding.is_default"`)}
 	}
 	return nil
 }
@@ -167,6 +188,10 @@ func (_c *GameAccountBindingCreate) createSpec() (*GameAccountBinding, *sqlgraph
 	if value, ok := _c.mutation.Verified(); ok {
 		_spec.SetField(gameaccountbinding.FieldVerified, field.TypeBool, value)
 		_node.Verified = value
+	}
+	if value, ok := _c.mutation.IsDefault(); ok {
+		_spec.SetField(gameaccountbinding.FieldIsDefault, field.TypeBool, value)
+		_node.IsDefault = value
 	}
 	if value, ok := _c.mutation.Suite(); ok {
 		_spec.SetField(gameaccountbinding.FieldSuite, field.TypeJSON, value)

--- a/utils/database/postgresql/gameaccountbinding_update.go
+++ b/utils/database/postgresql/gameaccountbinding_update.go
@@ -71,6 +71,20 @@ func (_u *GameAccountBindingUpdate) SetNillableVerified(v *bool) *GameAccountBin
 	return _u
 }
 
+// SetIsDefault sets the "is_default" field.
+func (_u *GameAccountBindingUpdate) SetIsDefault(v bool) *GameAccountBindingUpdate {
+	_u.mutation.SetIsDefault(v)
+	return _u
+}
+
+// SetNillableIsDefault sets the "is_default" field if the given value is not nil.
+func (_u *GameAccountBindingUpdate) SetNillableIsDefault(v *bool) *GameAccountBindingUpdate {
+	if v != nil {
+		_u.SetIsDefault(*v)
+	}
+	return _u
+}
+
 // SetSuite sets the "suite" field.
 func (_u *GameAccountBindingUpdate) SetSuite(v *schema.SuiteDataPrivacySettings) *GameAccountBindingUpdate {
 	_u.mutation.SetSuite(v)
@@ -169,6 +183,9 @@ func (_u *GameAccountBindingUpdate) sqlSave(ctx context.Context) (_node int, err
 	}
 	if value, ok := _u.mutation.Verified(); ok {
 		_spec.SetField(gameaccountbinding.FieldVerified, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.IsDefault(); ok {
+		_spec.SetField(gameaccountbinding.FieldIsDefault, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.Suite(); ok {
 		_spec.SetField(gameaccountbinding.FieldSuite, field.TypeJSON, value)
@@ -269,6 +286,20 @@ func (_u *GameAccountBindingUpdateOne) SetVerified(v bool) *GameAccountBindingUp
 func (_u *GameAccountBindingUpdateOne) SetNillableVerified(v *bool) *GameAccountBindingUpdateOne {
 	if v != nil {
 		_u.SetVerified(*v)
+	}
+	return _u
+}
+
+// SetIsDefault sets the "is_default" field.
+func (_u *GameAccountBindingUpdateOne) SetIsDefault(v bool) *GameAccountBindingUpdateOne {
+	_u.mutation.SetIsDefault(v)
+	return _u
+}
+
+// SetNillableIsDefault sets the "is_default" field if the given value is not nil.
+func (_u *GameAccountBindingUpdateOne) SetNillableIsDefault(v *bool) *GameAccountBindingUpdateOne {
+	if v != nil {
+		_u.SetIsDefault(*v)
 	}
 	return _u
 }
@@ -401,6 +432,9 @@ func (_u *GameAccountBindingUpdateOne) sqlSave(ctx context.Context) (_node *Game
 	}
 	if value, ok := _u.mutation.Verified(); ok {
 		_spec.SetField(gameaccountbinding.FieldVerified, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.IsDefault(); ok {
+		_spec.SetField(gameaccountbinding.FieldIsDefault, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.Suite(); ok {
 		_spec.SetField(gameaccountbinding.FieldSuite, field.TypeJSON, value)

--- a/utils/database/postgresql/migrate/schema.go
+++ b/utils/database/postgresql/migrate/schema.go
@@ -62,6 +62,7 @@ var (
 		{Name: "server", Type: field.TypeString},
 		{Name: "game_user_id", Type: field.TypeString},
 		{Name: "verified", Type: field.TypeBool, Default: false},
+		{Name: "is_default", Type: field.TypeBool, Default: false},
 		{Name: "suite", Type: field.TypeJSON, Nullable: true},
 		{Name: "mysekai", Type: field.TypeJSON, Nullable: true},
 		{Name: "user_game_account_bindings", Type: field.TypeString, Nullable: true},
@@ -74,7 +75,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "game_account_bindings_users_game_account_bindings",
-				Columns:    []*schema.Column{GameAccountBindingsColumns[6]},
+				Columns:    []*schema.Column{GameAccountBindingsColumns[7]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -88,7 +89,7 @@ var (
 			{
 				Name:    "gameaccountbinding_user_game_account_bindings",
 				Unique:  false,
-				Columns: []*schema.Column{GameAccountBindingsColumns[6]},
+				Columns: []*schema.Column{GameAccountBindingsColumns[7]},
 			},
 		},
 	}

--- a/utils/database/postgresql/mutation.go
+++ b/utils/database/postgresql/mutation.go
@@ -1458,6 +1458,7 @@ type GameAccountBindingMutation struct {
 	server        *string
 	game_user_id  *string
 	verified      *bool
+	is_default    *bool
 	suite         **schema.SuiteDataPrivacySettings
 	mysekai       **schema.MysekaiDataPrivacySettings
 	clearedFields map[string]struct{}
@@ -1674,6 +1675,42 @@ func (m *GameAccountBindingMutation) ResetVerified() {
 	m.verified = nil
 }
 
+// SetIsDefault sets the "is_default" field.
+func (m *GameAccountBindingMutation) SetIsDefault(b bool) {
+	m.is_default = &b
+}
+
+// IsDefault returns the value of the "is_default" field in the mutation.
+func (m *GameAccountBindingMutation) IsDefault() (r bool, exists bool) {
+	v := m.is_default
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldIsDefault returns the old "is_default" field's value of the GameAccountBinding entity.
+// If the GameAccountBinding object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *GameAccountBindingMutation) OldIsDefault(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldIsDefault is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldIsDefault requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldIsDefault: %w", err)
+	}
+	return oldValue.IsDefault, nil
+}
+
+// ResetIsDefault resets all changes to the "is_default" field.
+func (m *GameAccountBindingMutation) ResetIsDefault() {
+	m.is_default = nil
+}
+
 // SetSuite sets the "suite" field.
 func (m *GameAccountBindingMutation) SetSuite(sdps *schema.SuiteDataPrivacySettings) {
 	m.suite = &sdps
@@ -1845,7 +1882,7 @@ func (m *GameAccountBindingMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *GameAccountBindingMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 6)
 	if m.server != nil {
 		fields = append(fields, gameaccountbinding.FieldServer)
 	}
@@ -1854,6 +1891,9 @@ func (m *GameAccountBindingMutation) Fields() []string {
 	}
 	if m.verified != nil {
 		fields = append(fields, gameaccountbinding.FieldVerified)
+	}
+	if m.is_default != nil {
+		fields = append(fields, gameaccountbinding.FieldIsDefault)
 	}
 	if m.suite != nil {
 		fields = append(fields, gameaccountbinding.FieldSuite)
@@ -1875,6 +1915,8 @@ func (m *GameAccountBindingMutation) Field(name string) (ent.Value, bool) {
 		return m.GameUserID()
 	case gameaccountbinding.FieldVerified:
 		return m.Verified()
+	case gameaccountbinding.FieldIsDefault:
+		return m.IsDefault()
 	case gameaccountbinding.FieldSuite:
 		return m.Suite()
 	case gameaccountbinding.FieldMysekai:
@@ -1894,6 +1936,8 @@ func (m *GameAccountBindingMutation) OldField(ctx context.Context, name string) 
 		return m.OldGameUserID(ctx)
 	case gameaccountbinding.FieldVerified:
 		return m.OldVerified(ctx)
+	case gameaccountbinding.FieldIsDefault:
+		return m.OldIsDefault(ctx)
 	case gameaccountbinding.FieldSuite:
 		return m.OldSuite(ctx)
 	case gameaccountbinding.FieldMysekai:
@@ -1927,6 +1971,13 @@ func (m *GameAccountBindingMutation) SetField(name string, value ent.Value) erro
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetVerified(v)
+		return nil
+	case gameaccountbinding.FieldIsDefault:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetIsDefault(v)
 		return nil
 	case gameaccountbinding.FieldSuite:
 		v, ok := value.(*schema.SuiteDataPrivacySettings)
@@ -2014,6 +2065,9 @@ func (m *GameAccountBindingMutation) ResetField(name string) error {
 		return nil
 	case gameaccountbinding.FieldVerified:
 		m.ResetVerified()
+		return nil
+	case gameaccountbinding.FieldIsDefault:
+		m.ResetIsDefault()
 		return nil
 	case gameaccountbinding.FieldSuite:
 		m.ResetSuite()

--- a/utils/database/postgresql/runtime.go
+++ b/utils/database/postgresql/runtime.go
@@ -65,6 +65,10 @@ func init() {
 	gameaccountbindingDescVerified := gameaccountbindingFields[2].Descriptor()
 	// gameaccountbinding.DefaultVerified holds the default value on creation for the verified field.
 	gameaccountbinding.DefaultVerified = gameaccountbindingDescVerified.Default.(bool)
+	// gameaccountbindingDescIsDefault is the schema descriptor for is_default field.
+	gameaccountbindingDescIsDefault := gameaccountbindingFields[3].Descriptor()
+	// gameaccountbinding.DefaultIsDefault holds the default value on creation for the is_default field.
+	gameaccountbinding.DefaultIsDefault = gameaccountbindingDescIsDefault.Default.(bool)
 	gameaccountdatagrantFields := schema.GameAccountDataGrant{}.Fields()
 	_ = gameaccountdatagrantFields
 	// gameaccountdatagrantDescOwnerUserID is the schema descriptor for owner_user_id field.


### PR DESCRIPTION
Adds a per-user global default game account, aligning the Toolbox binding model with the bot's default-binding concept.

- `game_account_bindings.is_default` (bool, default false); at most one per user, enforced in application transactions
- First binding a user creates (or receives while having no default) becomes the default automatically; a transferred binding never keeps the previous owner's flag
- `PATCH /api/user/{id}/game-account/{server}/{game_user_id}` accepts optional `isDefault` (true = clear-then-set in one tx, false = unset)
- `isDefault` exposed in settings/binding responses, admin binding lists, and the private bindings query used by HarukiBot NEO
- No data migration needed: legacy rows stay false and clients fall back to first-binding until a default is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cayo3AREQGnnLnia6gYkp8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Game account bindings can now be marked as a user’s default account.
  * The first binding is automatically selected as default when appropriate.
  * Users can switch their default account, with only one default binding retained.
  * Default status is included in account-binding responses and can be provided when creating or updating bindings.
* **Bug Fixes**
  * Transferred bindings now correctly lose or gain default status based on the new owner’s existing accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->